### PR TITLE
Feat/entity: 유저, 깃허브계정 JPA 엔티티 작성

### DIFF
--- a/sosd-backend/build.gradle
+++ b/sosd-backend/build.gradle
@@ -21,6 +21,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // jpa
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 
 tasks.named('test') {

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/README.md
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/README.md
@@ -1,0 +1,51 @@
+### 📁 `entity/` 디렉토리
+
+이 디렉토리는 프로젝트의 **도메인 목표(Entity)** 클래스를 정의합니다.
+각 클래스는 데이터베이스 테이블과 매핑되며, JPA 또는 ORM 프레임워크를 사용해서 영속성 처리를 담당합니다.
+
+---
+
+### 📌 주요 목적
+
+* 데이터베이스 테이블과의 매핑
+* 도메인 객체 구조 정의
+* 연관 관계(OneToMany, ManyToOne 등) 설정
+* 기본 생성자, equals/hashCode, toString 정의 등
+
+---
+
+### 📆 예시 클래스
+
+```java
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    // 기본 생성자 (JPA용)
+    protected User() {}
+
+    // 일반 생성자 (비즈니스 로직용)
+    public User(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    // Getter, Setter, Constructor, equals/hashCode, toString 등
+}
+```
+
+---
+
+### 📙 규칙
+
+* `@Entity` 애너테이션 필수
+* 기본 생성자(default constructor) 필요
+* 연관 관계는 명확히 명시
+* 비지니스 로직은 가까운 Service 레이어로 분리

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
@@ -56,6 +56,7 @@ public class GithubAccount {
         this.githubName = githubName;
         this.githubToken = githubToken;
         this.githubEmail = githubEmail;
+        this.lastCrawling = null;
         this.userAccount = userAccount;
     }
 

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
@@ -1,0 +1,67 @@
+package com.sosd.sosd_backend.entity.github;
+
+import com.sosd.sosd_backend.entity.user.UserAccount;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "github_account")
+public class GithubAccount {
+
+    // 기본키
+    @Id
+    @Column(name = "github_id")
+    private Long githubId;
+
+    // 일반 컬럼
+    @Column(name = "github_login", nullable = false)
+    private String githubLogin;
+
+    @Column(name = "github_name")
+    private String githubName;
+
+    @Column(name = "github_token")
+    private String githubToken;
+
+    @Column(name = "github_email", nullable = false)
+    private String githubEmail;
+
+    @Column(name = "last_crawling")
+    private LocalDateTime lastCrawling;
+
+    // 연관관계 설정
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private UserAccount userAccount;
+
+    // 생성자
+    @Builder
+    public GithubAccount(
+            Long githubId,
+            String githubLogin,
+            String githubName,
+            String githubToken,
+            String githubEmail,
+            UserAccount userAccount
+    ) {
+        this.githubId = githubId;
+        this.githubLogin = githubLogin;
+        this.githubName = githubName;
+        this.githubToken = githubToken;
+        this.githubEmail = githubEmail;
+        this.userAccount = userAccount;
+    }
+
+    // 수집기 작동 시 호출 메소드
+    public void updateLastCrawling() {
+        this.lastCrawling = LocalDateTime.now();
+    }
+
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
@@ -1,11 +1,10 @@
 package com.sosd.sosd_backend.entity.user;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.sosd.sosd_backend.entity.github.GithubAccount;
+import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -19,11 +18,12 @@ import org.hibernate.annotations.CreationTimestamp;
 @Table(name = "user_account")
 public class UserAccount {
 
-    // 데이터베이스 필드
+    // 기본 키
     @Id
     @Column(name = "student_id", length = 20)
     private String studentId; // SSO로 받은 학교 학번 사용
 
+    // 일반 컬럼
     @Column(nullable = false, length = 40)
     private String name;
 
@@ -58,6 +58,11 @@ public class UserAccount {
     @Column(name = "is_active")
     private boolean isActive;
 
+    // 연관관계 설정
+    @OneToMany(mappedBy = "userAccount", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GithubAccount> githubAccounts;
+
+    // 생성자
     @Builder
     public UserAccount(
             String studentId,

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
@@ -1,10 +1,8 @@
 package com.sosd.sosd_backend.entity.user;
 
-import com.sosd.sosd_backend.entity.github.GithubAccount;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
@@ -58,10 +58,6 @@ public class UserAccount {
     @Column(name = "is_active")
     private boolean isActive;
 
-    // 연관관계 설정
-    @OneToMany(mappedBy = "userAccount", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<GithubAccount> githubAccounts;
-
     // 생성자
     @Builder
     public UserAccount(

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/user/UserAccount.java
@@ -1,0 +1,93 @@
+package com.sosd.sosd_backend.entity.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user_account")
+public class UserAccount {
+
+    // 데이터베이스 필드
+    @Id
+    @Column(name = "student_id", length = 20)
+    private String studentId; // SSO로 받은 학교 학번 사용
+
+    @Column(nullable = false, length = 40)
+    private String name;
+
+    private int role;
+
+    @Column(nullable = false)
+    private String college;
+
+    @Column(nullable = false)
+    private String dept;
+
+    @Column(name = "plural_major")
+    private int pluralMajor;
+
+    private String photo;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    @Column(columnDefinition = "TEXT")
+    private String portfolio;
+
+    @CreationTimestamp
+    @Column(name = "date_joined",  nullable = false)
+    private LocalDateTime dateJoined;
+
+    @Column(name = "last_login")
+    private LocalDateTime lastLogin;
+
+    private int absence;
+
+    @Column(name = "is_active")
+    private boolean isActive;
+
+    @Builder
+    public UserAccount(
+            String studentId,
+            String name,
+            int role,
+            String college,
+            String dept,
+            int pluralMajor,
+            String photo,
+            String introduction,
+            String portfolio,
+            int absence,
+            boolean isActive
+    ) {
+        this.studentId = studentId;
+        this.name = name;
+        this.role = role;
+        this.college = college;
+        this.dept = dept;
+        this.pluralMajor = pluralMajor;
+        this.photo = photo;
+        this.introduction = introduction;
+        this.portfolio = portfolio;
+        this.absence = absence;
+        this.isActive = isActive;
+        this.lastLogin = null; // 로그인 시 업데이트
+    }
+
+    // 로그인 시 호출 메소드
+    public void updateLastLogin() {
+        this.lastLogin = LocalDateTime.now();
+    }
+}

--- a/sosd-backend/src/main/resources/schema/github-schema.sql
+++ b/sosd-backend/src/main/resources/schema/github-schema.sql
@@ -1,0 +1,23 @@
+-- src/main/resources/schema/002-github-schema.sql
+
+-- GitHub 계정 테이블
+CREATE TABLE IF NOT EXISTS github_account (
+    github_id BIGINT NOT NULL PRIMARY KEY COMMENT 'GitHub ID(Github 내부적으로 사용하는 고유 id)',
+    github_login VARCHAR(255) NOT NULL COMMENT 'GitHub 로그인명 (username)',
+    github_name VARCHAR(255) COMMENT 'GitHub 표시명',
+    github_token VARCHAR(255) COMMENT 'GitHub 액세스 토큰(private 레포까지 수집 원하는 유저만 추가)',
+    github_email VARCHAR(255) NOT NULL COMMENT 'GitHub 이메일',
+    last_crawling TIMESTAMP NULL COMMENT '마지막 크롤링 일시',
+    student_id VARCHAR(20) NOT NULL COMMENT '연결된 학번 (외래키)',
+
+    -- 외래키 제약조건
+    CONSTRAINT fk_github_account_user
+    FOREIGN KEY (student_id)
+    REFERENCES user_account(student_id)
+    ON DELETE CASCADE ON UPDATE CASCADE
+
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub 계정 테이블';
+
+-- 인덱스 추가
+CREATE INDEX IF NOT EXISTS idx_github_account_login ON github_account(github_login);
+CREATE INDEX IF NOT EXISTS idx_github_account_last_crawling ON github_account(last_crawling);

--- a/sosd-backend/src/main/resources/schema/github-schema.sql
+++ b/sosd-backend/src/main/resources/schema/github-schema.sql
@@ -18,6 +18,12 @@ CREATE TABLE IF NOT EXISTS github_account (
 
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub 계정 테이블';
 
--- 인덱스 추가
+-- ================================
+-- 인덱스 생성
+-- ================================
+
+-- username을 통한 조회용
 CREATE INDEX IF NOT EXISTS idx_github_account_login ON github_account(github_login);
+
+-- 스케쥴링할 때 기간 쿼리용
 CREATE INDEX IF NOT EXISTS idx_github_account_last_crawling ON github_account(last_crawling);

--- a/sosd-backend/src/main/resources/schema/user-schema.sql
+++ b/sosd-backend/src/main/resources/schema/user-schema.sql
@@ -1,5 +1,6 @@
 -- src/main/resources/schema/user-schema.sql
 
+-- 유저 테이블
 CREATE TABLE IF NOT EXISTS user_account (
     student_id VARCHAR(20) NOT NULL PRIMARY KEY COMMENT '학번 (SSO)',
     name VARCHAR(40) NOT NULL COMMENT '이름(SSO)',
@@ -15,3 +16,19 @@ CREATE TABLE IF NOT EXISTS user_account (
     absence INT NOT NULL DEFAULT 0 COMMENT '재학 여부 (0: 재학, 1: 휴학, 2: 졸업 등)',
     is_active BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성 상태'
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 계정 테이블';
+
+-- ================================
+-- 인덱스 생성
+-- ================================
+
+-- 활성 시용자 조회용
+CREATE INDEX IF NOT EXISTS idx_user_is_active ON user_account(is_active);
+
+-- 재학생 통계용
+CREATE INDEX IF NOT EXISTS idx_user_active_college_dept ON user_account(is_active, college, dept);
+
+-- 가입자 분석용
+CREATE INDEX IF NOT EXISTS idx_user_date_joined ON user_account(date_joined);
+
+-- 활동 분석용
+CREATE INDEX IF NOT EXISTS idx_user_last_login ON user_account(last_login);

--- a/sosd-backend/src/main/resources/schema/user-schema.sql
+++ b/sosd-backend/src/main/resources/schema/user-schema.sql
@@ -21,11 +21,11 @@ CREATE TABLE IF NOT EXISTS user_account (
 -- 인덱스 생성
 -- ================================
 
--- 활성 시용자 조회용
-CREATE INDEX IF NOT EXISTS idx_user_is_active ON user_account(is_active);
+-- 재학 여부 필터용
+CREATE INDEX IF NOT EXISTS idx_user_is_active ON user_account(absence);
 
 -- 재학생 통계용
-CREATE INDEX IF NOT EXISTS idx_user_active_college_dept ON user_account(is_active, college, dept);
+CREATE INDEX IF NOT EXISTS idx_user_active_college_dept ON user_account(is_active, college, dept, absence);
 
 -- 가입자 분석용
 CREATE INDEX IF NOT EXISTS idx_user_date_joined ON user_account(date_joined);

--- a/sosd-backend/src/main/resources/schema/user-schema.sql
+++ b/sosd-backend/src/main/resources/schema/user-schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS user_account (
 -- ================================
 
 -- 재학 여부 필터용
-CREATE INDEX IF NOT EXISTS idx_user_is_active ON user_account(absence);
+CREATE INDEX IF NOT EXISTS idx_user_absence ON user_account(absence);
 
 -- 재학생 통계용
 CREATE INDEX IF NOT EXISTS idx_user_active_college_dept ON user_account(is_active, college, dept, absence);

--- a/sosd-backend/src/main/resources/schema/user-schema.sql
+++ b/sosd-backend/src/main/resources/schema/user-schema.sql
@@ -1,0 +1,17 @@
+-- src/main/resources/schema/user-schema.sql
+
+CREATE TABLE IF NOT EXISTS user_account (
+    student_id VARCHAR(20) NOT NULL PRIMARY KEY COMMENT '학번 (SSO)',
+    name VARCHAR(40) NOT NULL COMMENT '이름(SSO)',
+    role INT NOT NULL DEFAULT 0 COMMENT '역할 (0: 일반회원, 1: 관리자 등), 추후 역할 추가 가능성이 있기에 int로 설정',
+    college VARCHAR(255) NOT NULL COMMENT '단과대학',
+    dept VARCHAR(255) NOT NULL COMMENT '학과',
+    plural_major INT DEFAULT 0 COMMENT '복수전공 여부',
+    photo VARCHAR(255) COMMENT '프로필 사진 URL',
+    introduction TEXT COMMENT '자기소개',
+    portfolio TEXT COMMENT '포트폴리오',
+    date_joined TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '가입일시',
+    last_login TIMESTAMP NULL COMMENT '마지막 로그인',
+    absence INT NOT NULL DEFAULT 0 COMMENT '휴학',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성 상태'
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 계정 테이블';

--- a/sosd-backend/src/main/resources/schema/user-schema.sql
+++ b/sosd-backend/src/main/resources/schema/user-schema.sql
@@ -12,6 +12,6 @@ CREATE TABLE IF NOT EXISTS user_account (
     portfolio TEXT COMMENT '포트폴리오',
     date_joined TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '가입일시',
     last_login TIMESTAMP NULL COMMENT '마지막 로그인',
-    absence INT NOT NULL DEFAULT 0 COMMENT '휴학',
+    absence INT NOT NULL DEFAULT 0 COMMENT '재학 여부 (0: 재학, 1: 휴학, 2: 졸업 등)',
     is_active BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성 상태'
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 계정 테이블';


### PR DESCRIPTION
## 📌 PR 개요

User와 Github 계정 간의 관계를 관리하기 위한 JPA 엔티티를 추가

## 🛠 작업 내용

**UserAccount 엔티티 추가**
 - 사용자 기본 정보 관리 (학번, 이름, 학과 등)
 - 자동 생성 필드 처리 (`@CreationTimestamp`)
 - 로그인 시간 업데이트 메서드 구현

**GithubAccount 엔티티 추가**
 - Github 계정 정보 관리 (ID, 로그인명, 토큰 등)
 - 크롤링 시간 업데이트 메서드 구현

**연관관계 설정**
 - UserAccount(1) : GithubAccount(N) 양방향 매핑
 - 
### 스크린샷 (선택)
ERD 다이어그램(데이터타입이 안나와있는데 참고삼아 올립니다)
<img width="800" height="979" alt="스크린샷 2025-07-30 오후 3 53 16" src="https://github.com/user-attachments/assets/63567c7f-8ae8-47af-ae20-dfdf4040eb1d" />

## 🔗 연관된 이슈

- closes #이슈번호