### PR TITLE
feat: GitHub Repository 수집 서비스 구현

### DIFF
--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/RepositoryDetailDto.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/RepositoryDetailDto.java
@@ -28,4 +28,18 @@ public record RepositoryDetailDto(
     public record LicenseDto(
             String name
     ) {}
+
+    /** fullName에서 repoName 부분만 추출 */
+    public String repoNameOnly() {
+        if (fullName == null) return null;
+        int idx = fullName.indexOf('/');
+        return (idx >= 0 && idx + 1 < fullName.length()) ? fullName.substring(idx + 1) : fullName;
+    }
+
+    /** fullName에서 ownerName 부분만 추출 */
+    public String ownerNameOnly() {
+        if (fullName == null) return null;
+        int idx = fullName.indexOf('/');
+        return (idx > 0) ? fullName.substring(0, idx) : null;
+    }
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubAccountRepository.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubAccountRepository.java
@@ -1,0 +1,24 @@
+package com.sosd.sosd_backend.repository.github;
+
+import com.sosd.sosd_backend.entity.github.GithubAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GithubAccountRepository extends JpaRepository<GithubAccount, Long> {
+
+    // PK로 조회
+    boolean existsByGithubId(Long githubId);
+    Optional<GithubAccount> findByGithubId(Long githubId);
+
+    // 유저네임으로 조회
+    boolean existsByGithubLoginUsername(String githubLoginUsername);
+    Optional<GithubAccount> findByGithubLoginUsername(String githubLoginUsername);
+
+    // FK - 학번 기준 조회
+    List<GithubAccount> findAllByUserAccount_StudentId(String studentId);
+
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
@@ -1,7 +1,7 @@
 package com.sosd.sosd_backend.repository.github;
 
 import com.sosd.sosd_backend.entity.github.GithubAccount;
-import com.sosd.sosd_backend.entity.github.GithubRepository;
+import com.sosd.sosd_backend.entity.github.GithubRepositoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,25 +11,25 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface GithubRepositoryRepository extends JpaRepository<GithubRepository, Long> {
+public interface GithubRepositoryRepository extends JpaRepository<GithubRepositoryEntity, Long> {
 
     // PK로 단건 조회
     boolean existsByRepoId(Long repoId);
-    Optional<GithubRepository> findByRepoId(Long repoId);
+    Optional<GithubRepositoryEntity> findByRepoId(Long repoId);
 
     // 유니크 인덱스
     boolean existsByOwnerNameAndRepoName(String ownerName, String repoName);
-    Optional<GithubRepository> findByOwnerNameAndRepoName(String ownerName, String repoName);
+    Optional<GithubRepositoryEntity> findByOwnerNameAndRepoName(String ownerName, String repoName);
 
     // GithubAccount로 일괄 조회
-    List<GithubRepository> findAllByGithubAccount(GithubAccount githubAccount);
+    List<GithubRepositoryEntity> findAllByGithubAccount(GithubAccount githubAccount);
 
     // GithubAccount의 PK(=github_id)로 조회
-    List<GithubRepository> findAllByGithubAccount_GithubId(Integer githubId);
+    List<GithubRepositoryEntity> findAllByGithubAccount_GithubId(Integer githubId);
 
-    List<GithubRepository> findAllByGithubAccount_GithubLoginUsername(String githubLoginUsername);
+    List<GithubRepositoryEntity> findAllByGithubAccount_GithubLoginUsername(String githubLoginUsername);
 
     // 여러 repoId로 한 번에 조회
-    List<GithubRepository> findAllByRepoIdIn(Collection<Integer> repoIds);
+    List<GithubRepositoryEntity> findAllByRepoIdIn(Collection<Integer> repoIds);
 
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
@@ -1,0 +1,35 @@
+package com.sosd.sosd_backend.repository.github;
+
+import com.sosd.sosd_backend.entity.github.GithubAccount;
+import com.sosd.sosd_backend.entity.github.GithubRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GithubRepositoryRepository extends JpaRepository<GithubRepository, Long> {
+
+    // PK로 단건 조회
+    boolean existsByRepoId(Long repoId);
+    Optional<GithubRepository> findByRepoId(Long repoId);
+
+    // 유니크 인덱스
+    boolean existsByOwnerNameAndRepoName(String ownerName, String repoName);
+    Optional<GithubRepository> findByOwnerNameAndRepoName(String ownerName, String repoName);
+
+    // GithubAccount로 일괄 조회
+    List<GithubRepository> findAllByGithubAccount(GithubAccount githubAccount);
+
+    // GithubAccount의 PK(=github_id)로 조회
+    List<GithubRepository> findAllByGithubAccount_GithubId(Integer githubId);
+
+    List<GithubRepository> findAllByGithubAccount_GithubLoginUsername(String githubLoginUsername);
+
+    // 여러 repoId로 한 번에 조회
+    List<GithubRepository> findAllByRepoIdIn(Collection<Integer> repoIds);
+
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
@@ -1,0 +1,77 @@
+package com.sosd.sosd_backend.service.github;
+
+import com.sosd.sosd_backend.dto.RepositoryDetailDto;
+import com.sosd.sosd_backend.entity.github.GithubAccount;
+import com.sosd.sosd_backend.entity.github.GithubRepository;
+import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
+import com.sosd.sosd_backend.repository.github.GithubAccountRepository;
+import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RepoIngestionService {
+
+    private final RepoCollector repoCollector;
+    private final GithubRepositoryRepository githubRepositoryRepository;
+    private final GithubAccountRepository githubAccountRepository;
+
+
+    /**
+     * Github Account 단위 요청
+     * github username을 받아서 기여한 모든 레포 수집 후 DB upsert
+     */
+    @Transactional
+    public void ingestAccount(String githubLoginUsername){
+        // 1) 깃허브 api를 통해 수집
+        List<RepositoryDetailDto> dtos = repoCollector.getAllContributedRepos(githubLoginUsername);
+
+        // 2) 저장
+        upsertRepos(githubLoginUsername, dtos);
+
+    }
+
+    private void upsertRepos(String githubLoginUsername, List<RepositoryDetailDto> dtos){
+        // 2-1) 계정 로딩
+        GithubAccount account = githubAccountRepository.findByGithubLoginUsername(githubLoginUsername)
+                .orElseThrow(()->new RuntimeException("GithubAccount 없음: " + githubLoginUsername));
+
+        // 2-2)
+        List<GithubRepository> entities = dtos.stream()
+                .map(dto -> toEntity(dto, account))
+                .toList();
+
+        // 2-3) 저장 (repository는 보통 그렇게 많지 않기 때문에 네이티브 사용x)
+        githubRepositoryRepository.saveAll(entities);
+    }
+
+
+    private GithubRepository toEntity(RepositoryDetailDto dto, GithubAccount account){
+        return GithubRepository.builder()
+                .repoId(dto.id())
+                .ownerName(dto.ownerNameOnly())
+                .repoName(dto.repoNameOnly())
+                .defaultBranch(nvl(dto.defaultBranch(), "main"))
+                .githubRepositoryCreatedAt(toUtcLocal(dto.createdAt()))
+                .githubRepositoryUpdatedAt(toUtcLocal(dto.updatedAt()))
+                .pushedAt(toUtcLocal(dto.pushedAt()))
+                .githubAccount(account)
+                .build();
+    }
+
+    private static LocalDateTime toUtcLocal(OffsetDateTime odt) {
+        return odt != null ? odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+    }
+
+    private static String nvl(String v, String def) {
+        return (v == null || v.isEmpty()) ? def : v;
+    }
+
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
@@ -2,7 +2,7 @@ package com.sosd.sosd_backend.service.github;
 
 import com.sosd.sosd_backend.dto.RepositoryDetailDto;
 import com.sosd.sosd_backend.entity.github.GithubAccount;
-import com.sosd.sosd_backend.entity.github.GithubRepository;
+import com.sosd.sosd_backend.entity.github.GithubRepositoryEntity;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
 import com.sosd.sosd_backend.repository.github.GithubAccountRepository;
 import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
@@ -44,7 +44,7 @@ public class RepoIngestionService {
                 .orElseThrow(()->new RuntimeException("GithubAccount 없음: " + githubLoginUsername));
 
         // 2-2)
-        List<GithubRepository> entities = dtos.stream()
+        List<GithubRepositoryEntity> entities = dtos.stream()
                 .map(dto -> toEntity(dto, account))
                 .toList();
 
@@ -53,8 +53,8 @@ public class RepoIngestionService {
     }
 
 
-    private GithubRepository toEntity(RepositoryDetailDto dto, GithubAccount account){
-        return GithubRepository.builder()
+    private GithubRepositoryEntity toEntity(RepositoryDetailDto dto, GithubAccount account){
+        return GithubRepositoryEntity.builder()
                 .repoId(dto.id())
                 .ownerName(dto.ownerNameOnly())
                 .repoName(dto.repoNameOnly())

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
@@ -29,7 +29,7 @@ public class RepoIngestionService {
      * github username을 받아서 기여한 모든 레포 수집 후 DB upsert
      */
     @Transactional
-    public void ingestAccount(String githubLoginUsername){
+    public void ingestGithubAccount(String githubLoginUsername){
         // 1) 깃허브 api를 통해 수집
         List<RepositoryDetailDto> dtos = repoCollector.getAllContributedRepos(githubLoginUsername);
 

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
@@ -1,0 +1,73 @@
+package com.sosd.sosd_backend.service.github;
+
+import com.sosd.sosd_backend.dto.RepositoryDetailDto;
+import com.sosd.sosd_backend.entity.github.GithubAccount;
+import com.sosd.sosd_backend.entity.github.GithubRepositoryEntity;
+import com.sosd.sosd_backend.repository.github.GithubAccountRepository;
+import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RepoUpsertService {
+
+    private final GithubRepositoryRepository githubRepositoryRepository;
+    private final GithubAccountRepository githubAccountRepository;
+
+    /**
+     * 주어진 GitHub 계정이 기여한 저장소 목록을 DB에 Upsert(Insert or Update) 처리합니다.
+     * <ul>
+     *   <li>PK(repoId) 기준 신규 저장소는 INSERT, 기존 저장소는 UPDATE 수행</li>
+     *   <li>호출 전 외부 API 수집은 완료되어 있어야 함</li>
+     *   <li>트랜잭션 전체를 커버하여 원자성 보장</li>
+     * </ul>
+     *
+     * @param githubLoginUsername GitHub 계정 로그인 ID
+     * @param dtos 수집된 저장소 상세 정보 리스트
+     * @throws RuntimeException 해당 계정이 DB에 존재하지 않을 경우
+     */
+    @Transactional
+    public void upsertRepos(String githubLoginUsername, List<RepositoryDetailDto> dtos){
+        // 2-1) 계정 로딩
+        GithubAccount githubAccount = githubAccountRepository.findByGithubLoginUsername(githubLoginUsername)
+                .orElseThrow(() -> new RuntimeException("Github Account 없음: " + githubLoginUsername));
+
+        // 2-2) 레포지토리 엔티티로 변환
+        List<GithubRepositoryEntity> entities = dtos.stream()
+                .map(dto -> toEntity(dto, githubAccount))
+                .toList();
+
+        // 2-3) 저장 (한 계정이 보유한 repository는 보통 그렇게 많지 않기 때문에 네이티브 사용x)
+        githubRepositoryRepository.saveAll(entities);
+
+    }
+
+    private GithubRepositoryEntity toEntity(RepositoryDetailDto dto, GithubAccount account){
+        return GithubRepositoryEntity.builder()
+                .repoId(dto.id())
+                .ownerName(dto.ownerNameOnly())
+                .repoName(dto.repoNameOnly())
+                .defaultBranch(nvl(dto.defaultBranch(), "main"))
+                .githubRepositoryCreatedAt(toUtcLocal(dto.createdAt()))
+                .githubRepositoryUpdatedAt(toUtcLocal(dto.updatedAt()))
+                .pushedAt(toUtcLocal(dto.pushedAt()))
+                .githubAccount(account)
+                .build();
+    }
+
+    private static LocalDateTime toUtcLocal(OffsetDateTime odt) {
+        return odt != null ? odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+    }
+
+    private static String nvl(String v, String def) {
+        return (v == null || v.isEmpty()) ? def : v;
+    }
+
+}

--- a/sosd-backend/src/main/resources/application-local.properties
+++ b/sosd-backend/src/main/resources/application-local.properties
@@ -12,6 +12,7 @@ spring.sql.init.mode=always
 spring.sql.init.schema-locations=\
   classpath:schema/user-schema.sql,\
   classpath:schema/github-schema.sql
+spring.sql.init.data-locations=classpath:data/dev-seed.sql
 spring.sql.init.encoding=UTF-8
 spring.sql.init.continue-on-error=false
 spring.sql.init.separator=;
@@ -22,6 +23,7 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 logging.level.org.springframework.jdbc.datasource.init=DEBUG
 logging.level.com.zaxxer.hikari=DEBUG
+
 
 # .env ?? ????
 spring.config.import=optional:file:.env[.properties]

--- a/sosd-backend/src/main/resources/application-local.properties
+++ b/sosd-backend/src/main/resources/application-local.properties
@@ -26,7 +26,9 @@ logging.level.com.zaxxer.hikari=DEBUG
 
 
 # .env ?? ????
-spring.config.import=optional:file:.env[.properties]
+spring.config.import=\
+  optional:file:./.env[.properties],\
+  optional:file:../.env[.properties]
 
 # github.token ????? .env ?? ??
 github.token=${GITHUB_TOKEN}

--- a/sosd-backend/src/main/resources/data/dev-seed.sql
+++ b/sosd-backend/src/main/resources/data/dev-seed.sql
@@ -1,0 +1,42 @@
+-- 기본 유저 계정 데이터
+INSERT INTO user_account (
+    student_id, name, role, college, dept, plural_major, photo, introduction, portfolio,
+    date_joined, updated_at, last_login, absence, is_active
+)
+VALUES (
+           '2020315013', -- 학번
+           '강병희', -- 이름
+           0,           -- 역할
+           '소프트웨어대학', -- 단과대학
+           '소프트웨어학과', -- 학과
+           0,           -- 복수전공 여부
+           NULL,        -- 프로필 사진
+           '안녕하세요. 테스트 계정입니다.', -- 자기소개
+           NULL,        -- 포트폴리오
+           NOW(),       -- 가입일
+           NOW(),       -- 업데이트일
+           NULL,        -- 마지막 로그인
+           0,           -- 재학
+           TRUE         -- 활성 상태
+       )
+    ON DUPLICATE KEY UPDATE
+                         name = VALUES(name),
+                         updated_at = NOW();
+
+-- GitHub 계정 데이터 (연결된 유저)
+INSERT INTO github_account (
+    github_id, github_login_username, github_name, github_token, github_email, last_crawling, student_id
+)
+VALUES (
+           80045655,              -- GitHub ID
+           'byungKHee',             -- GitHub username
+           NULL,         -- GitHub 표시명
+           NULL,                   -- GitHub 토큰
+           'byungheekang@g.skku.edu', -- 이메일
+           NULL,                   -- 마지막 크롤링
+           '2020315013'            -- 연결 학번
+       )
+    ON DUPLICATE KEY UPDATE
+                         github_name = VALUES(github_name),
+                         github_email = VALUES(github_email),
+                         last_crawling = VALUES(last_crawling);

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
@@ -28,7 +28,7 @@ public class RepoIngestionServiceTest {
         String githubLoginUsername = "byungKHee";
 
         // when
-        repoIngestionService.ingestAccount(githubLoginUsername);
+        repoIngestionService.ingestGithubAccount(githubLoginUsername);
 
         // then
         Iterable<GithubRepository> all = githubRepositoryRepository.findAll();

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
@@ -1,6 +1,6 @@
 package com.sosd.sosd_backend.service.github;
 
-import com.sosd.sosd_backend.entity.github.GithubRepository;
+import com.sosd.sosd_backend.entity.github.GithubRepositoryEntity;
 import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +31,7 @@ public class RepoIngestionServiceTest {
         repoIngestionService.ingestGithubAccount(githubLoginUsername);
 
         // then
-        Iterable<GithubRepository> all = githubRepositoryRepository.findAll();
+        Iterable<GithubRepositoryEntity> all = githubRepositoryRepository.findAll();
 
         assertThat(all).isNotEmpty();
         all.forEach(repo -> {

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/service/github/RepoIngestionServiceTest.java
@@ -1,0 +1,41 @@
+package com.sosd.sosd_backend.service.github;
+
+import com.sosd.sosd_backend.entity.github.GithubRepository;
+import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class RepoIngestionServiceTest {
+
+    @Autowired
+    private RepoIngestionService repoIngestionService;
+
+    @Autowired
+    private GithubRepositoryRepository githubRepositoryRepository;
+
+    @Test
+    void ingestUserRepo_save_test(){
+        // given
+        // 해당 유저가 테이블에 존재해야만 함
+        // 원래 서비스 흐름이 유저 조회 -> 유저 단위로 레포 수집이기 때문에 실제론 유저가 없을 일은 없을듯..?
+        String githubLoginUsername = "byungKHee";
+
+        // when
+        repoIngestionService.ingestAccount(githubLoginUsername);
+
+        // then
+        Iterable<GithubRepository> all = githubRepositoryRepository.findAll();
+
+        assertThat(all).isNotEmpty();
+        all.forEach(repo -> {
+            System.out.println(repo.getOwnerName() + "/" + repo.getRepoName());
+        });
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요

- GitHub 계정 단위로 Repository 데이터를 수집하고 DB에 저장하는 서비스 로직을 구현했습니다.
- 수집된 데이터의 DB 반영 여부를 검증하는 테스트 코드 작성.

## 🛠 작업 내용

- [x] `RepoIngestionService` 구현
    - `ingestGithubAccount(String githubLoginUsername)`
        - GithubAccount 조회
        - 해당 계정의 기여 Repository 수집
        - 엔티티 변환 후 저장
    -  `upsertRepos` 로 신구 저장/갱신 로직 통합

- [x] 테스트 코드 `RepoIngestionServiceTest` 작성
    - 실제 레포 수집 후 DB 저장 검증
    - 테스트 종료 시 롤백

- [x] 환경변수 .env 사용하도록 application 파일 수정 

## ❓ 기타 의견

이제 레포 단위의 수집 구현 후
유저 단위 -> 깃허브 단위 -> 레포 단위로 스케쥴러가 내려가도록 구현 예정