### PR TITLE
DB 구조 변경 및 레포 수집 구조 수정

### DIFF
--- a/sosd-backend/docs/github_schema.erd.json
+++ b/sosd-backend/docs/github_schema.erd.json
@@ -4,7 +4,7 @@
   "settings": {
     "width": 2000,
     "height": 2000,
-    "scrollTop": -475,
+    "scrollTop": 0,
     "scrollLeft": -800,
     "zoomLevel": 1,
     "show": 495,
@@ -157,7 +157,8 @@
           "mQFXIk1deHsl3s3mwS_iK",
           "zjok5tKh5bbSUEKVo6ExH",
           "C8_O2YpT1nzXd5dNGIcu-",
-          "uBavAwcvoGuLrO1oPEH1i"
+          "uBavAwcvoGuLrO1oPEH1i",
+          "XLg9Vdb6Kp9MID0BtvyCp"
         ],
         "seqColumnIds": [
           "SndfoACEixcnnO8PtUcQJ",
@@ -190,7 +191,8 @@
           "mQFXIk1deHsl3s3mwS_iK",
           "zjok5tKh5bbSUEKVo6ExH",
           "C8_O2YpT1nzXd5dNGIcu-",
-          "uBavAwcvoGuLrO1oPEH1i"
+          "uBavAwcvoGuLrO1oPEH1i",
+          "XLg9Vdb6Kp9MID0BtvyCp"
         ],
         "ui": {
           "x": 1289.2297,
@@ -201,7 +203,7 @@
           "color": "#FF5722"
         },
         "meta": {
-          "updateAt": 1754964511102,
+          "updateAt": 1754979307309,
           "createAt": 1752123292288
         }
       },
@@ -378,84 +380,6 @@
         "meta": {
           "updateAt": 1754964714715,
           "createAt": 1752129592485
-        }
-      },
-      "WrKJrit6zGutAjdlQ5e8X": {
-        "id": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "github_total_data",
-        "comment": "연도별 총 통계량(default branch만 반영)",
-        "columnIds": [
-          "T2qVY3i5JTAe-qUBiElRL",
-          "oUvQV6dHP7XQBq6KwwlwY",
-          "oDQxwfdiSLB-ZM-k_5P26",
-          "75XLyJyGqwOSiybJIVmLZ",
-          "adkbRhJ6Zc_ekqPnu7JTQ",
-          "LtnzqCEdOaqcAfrNFJGl_",
-          "7FLDoibJHUnbQMR34kSu2",
-          "e3bv6nSpf4L65cztwt6of",
-          "sNlLpOcAsLU_ZR8qaLfMz",
-          "GLqibB1L4E7y7YKFUF_BI"
-        ],
-        "seqColumnIds": [
-          "T2qVY3i5JTAe-qUBiElRL",
-          "oUvQV6dHP7XQBq6KwwlwY",
-          "oDQxwfdiSLB-ZM-k_5P26",
-          "75XLyJyGqwOSiybJIVmLZ",
-          "adkbRhJ6Zc_ekqPnu7JTQ",
-          "LtnzqCEdOaqcAfrNFJGl_",
-          "7FLDoibJHUnbQMR34kSu2",
-          "e3bv6nSpf4L65cztwt6of",
-          "sNlLpOcAsLU_ZR8qaLfMz",
-          "GLqibB1L4E7y7YKFUF_BI"
-        ],
-        "ui": {
-          "x": 367.3478,
-          "y": 1184.4347,
-          "zIndex": 786,
-          "widthName": 94,
-          "widthComment": 216,
-          "color": "#4CAF50"
-        },
-        "meta": {
-          "updateAt": 1752220113728,
-          "createAt": 1752219329055
-        }
-      },
-      "oYgEYkx0-sM1-Bw27sM6B": {
-        "id": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "github_score",
-        "comment": "",
-        "columnIds": [
-          "UlWidgU8sM_Vf6_2JJ-sU",
-          "MxtTCSlbg5AXeXygX7yKZ",
-          "SHtwCkTTl_Hi5shN8iVHC",
-          "4uxsfjUz3RNN0Qmmp4UyC",
-          "l7myLScWLmOOCQURO4M9G",
-          "Zupd_yM9fwxxJpus3SC2I",
-          "h4sHCSW23Cx251ytQM8YK",
-          "Vt9RMvYJwx8pnRZQTXXDS"
-        ],
-        "seqColumnIds": [
-          "UlWidgU8sM_Vf6_2JJ-sU",
-          "MxtTCSlbg5AXeXygX7yKZ",
-          "SHtwCkTTl_Hi5shN8iVHC",
-          "4uxsfjUz3RNN0Qmmp4UyC",
-          "l7myLScWLmOOCQURO4M9G",
-          "Zupd_yM9fwxxJpus3SC2I",
-          "h4sHCSW23Cx251ytQM8YK",
-          "Vt9RMvYJwx8pnRZQTXXDS"
-        ],
-        "ui": {
-          "x": -4,
-          "y": 1513,
-          "zIndex": 854,
-          "widthName": 70,
-          "widthComment": 60,
-          "color": "#4CAF50"
-        },
-        "meta": {
-          "updateAt": 1752220113728,
-          "createAt": 1752219521962
         }
       },
       "SSx8AS1rDk2wnLrBbaKFz": {
@@ -1211,60 +1135,60 @@
       "dYosxFHh6LcJUgg06bhLO": {
         "id": "dYosxFHh6LcJUgg06bhLO",
         "tableId": "tGokp1AVC2q5Qtig6dDGu",
-        "name": "commit_date",
+        "name": "github_pushed_at",
         "comment": "",
         "dataType": "DATETIME",
         "default": "",
         "options": 0,
         "ui": {
           "keys": 0,
-          "widthName": 71,
+          "widthName": 96,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1752220006406,
+          "updateAt": 1754979293642,
           "createAt": 1752125377760
         }
       },
       "mQFXIk1deHsl3s3mwS_iK": {
         "id": "mQFXIk1deHsl3s3mwS_iK",
         "tableId": "tGokp1AVC2q5Qtig6dDGu",
-        "name": "update_date",
+        "name": "github_update_date",
         "comment": "",
         "dataType": "DATETIME",
         "default": "",
         "options": 0,
         "ui": {
           "keys": 0,
-          "widthName": 68,
+          "widthName": 108,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1752220007968,
+          "updateAt": 1754979298123,
           "createAt": 1752125392196
         }
       },
       "zjok5tKh5bbSUEKVo6ExH": {
         "id": "zjok5tKh5bbSUEKVo6ExH",
         "tableId": "tGokp1AVC2q5Qtig6dDGu",
-        "name": "created_date",
+        "name": "github_created_date",
         "comment": "",
         "dataType": "DATETIME",
         "default": "",
         "options": 0,
         "ui": {
           "keys": 0,
-          "widthName": 70,
+          "widthName": 110,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1752220009593,
+          "updateAt": 1754979305224,
           "createAt": 1752125392342
         }
       },
@@ -2048,366 +1972,6 @@
           "createAt": 1752218627265
         }
       },
-      "T2qVY3i5JTAe-qUBiElRL": {
-        "id": "T2qVY3i5JTAe-qUBiElRL",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "id",
-        "comment": "auto",
-        "dataType": "INT",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219389250,
-          "createAt": 1752219370721
-        }
-      },
-      "oDQxwfdiSLB-ZM-k_5P26": {
-        "id": "oDQxwfdiSLB-ZM-k_5P26",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "year",
-        "comment": "github_id + year로 UQ1",
-        "dataType": "",
-        "default": "",
-        "options": 4,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 128,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219436899,
-          "createAt": 1752219391170
-        }
-      },
-      "oUvQV6dHP7XQBq6KwwlwY": {
-        "id": "oUvQV6dHP7XQBq6KwwlwY",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "github_id",
-        "comment": "깃허브에서 제공하는 Id",
-        "dataType": "BIGINT",
-        "default": "",
-        "options": 12,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 127,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219428140,
-          "createAt": 1752219406164
-        }
-      },
-      "75XLyJyGqwOSiybJIVmLZ": {
-        "id": "75XLyJyGqwOSiybJIVmLZ",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "commit_line",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 66,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219455721,
-          "createAt": 1752219440190
-        }
-      },
-      "adkbRhJ6Zc_ekqPnu7JTQ": {
-        "id": "adkbRhJ6Zc_ekqPnu7JTQ",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "commit_count",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 77,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219469189,
-          "createAt": 1752219458705
-        }
-      },
-      "LtnzqCEdOaqcAfrNFJGl_": {
-        "id": "LtnzqCEdOaqcAfrNFJGl_",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "pr_count",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219474560,
-          "createAt": 1752219472071
-        }
-      },
-      "7FLDoibJHUnbQMR34kSu2": {
-        "id": "7FLDoibJHUnbQMR34kSu2",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "issue_count",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 63,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219482089,
-          "createAt": 1752219475643
-        }
-      },
-      "e3bv6nSpf4L65cztwt6of": {
-        "id": "e3bv6nSpf4L65cztwt6of",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "star_count",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219487626,
-          "createAt": 1752219484056
-        }
-      },
-      "sNlLpOcAsLU_ZR8qaLfMz": {
-        "id": "sNlLpOcAsLU_ZR8qaLfMz",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "fork_count",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219495470,
-          "createAt": 1752219492791
-        }
-      },
-      "GLqibB1L4E7y7YKFUF_BI": {
-        "id": "GLqibB1L4E7y7YKFUF_BI",
-        "tableId": "WrKJrit6zGutAjdlQ5e8X",
-        "name": "score",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219499706,
-          "createAt": 1752219498024
-        }
-      },
-      "UlWidgU8sM_Vf6_2JJ-sU": {
-        "id": "UlWidgU8sM_Vf6_2JJ-sU",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "id",
-        "comment": "",
-        "dataType": "INT",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219685547,
-          "createAt": 1752219545812
-        }
-      },
-      "SHtwCkTTl_Hi5shN8iVHC": {
-        "id": "SHtwCkTTl_Hi5shN8iVHC",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "year",
-        "comment": "github_id + year로 UQ1",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 128,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219733076,
-          "createAt": 1752219686897
-        }
-      },
-      "MxtTCSlbg5AXeXygX7yKZ": {
-        "id": "MxtTCSlbg5AXeXygX7yKZ",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "github_id",
-        "comment": "깃허브에서 제공하는 Id",
-        "dataType": "BIGINT",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 127,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219695446,
-          "createAt": 1752219695446
-        }
-      },
-      "4uxsfjUz3RNN0Qmmp4UyC": {
-        "id": "4uxsfjUz3RNN0Qmmp4UyC",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "best_repo_name",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 88,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219748511,
-          "createAt": 1752219741833
-        }
-      },
-      "l7myLScWLmOOCQURO4M9G": {
-        "id": "l7myLScWLmOOCQURO4M9G",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "activity_level_score",
-        "comment": "활동 수준 점수",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 101,
-          "widthComment": 81,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219814747,
-          "createAt": 1752219753383
-        }
-      },
-      "Zupd_yM9fwxxJpus3SC2I": {
-        "id": "Zupd_yM9fwxxJpus3SC2I",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "activity_diversity_score",
-        "comment": "활동 다양성 점수",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 121,
-          "widthComment": 93,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219817765,
-          "createAt": 1752219785320
-        }
-      },
-      "h4sHCSW23Cx251ytQM8YK": {
-        "id": "h4sHCSW23Cx251ytQM8YK",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "activity_ influence_score",
-        "comment": "활동 영향력 점수",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 129,
-          "widthComment": 93,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219820511,
-          "createAt": 1752219793352
-        }
-      },
-      "Vt9RMvYJwx8pnRZQTXXDS": {
-        "id": "Vt9RMvYJwx8pnRZQTXXDS",
-        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-        "name": "score",
-        "comment": "총 점수",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1752219826751,
-          "createAt": 1752219821805
-        }
-      },
       "hZARCVqk90iOTqno46DJo": {
         "id": "hZARCVqk90iOTqno46DJo",
         "tableId": "tGokp1AVC2q5Qtig6dDGu",
@@ -2667,6 +2231,26 @@
           "updateAt": 1754978668669,
           "createAt": 1754964623406
         }
+      },
+      "XLg9Vdb6Kp9MID0BtvyCp": {
+        "id": "XLg9Vdb6Kp9MID0BtvyCp",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "additional_data",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 83,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754979314963,
+          "createAt": 1754979307309
+        }
       }
     },
     "relationshipEntities": {
@@ -2698,34 +2282,6 @@
           "createAt": 1752123128476
         }
       },
-      "Vh8rxmZNboXlKCGZcN4UB": {
-        "id": "Vh8rxmZNboXlKCGZcN4UB",
-        "identification": false,
-        "relationshipType": 4,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "M98IyDSU7ob4spyji_LWS",
-          "columnIds": [
-            "uPC2xJQDjEXYLzF4Jgl9C"
-          ],
-          "x": 560.4445,
-          "y": 932.6666,
-          "direction": 2
-        },
-        "end": {
-          "tableId": "tGokp1AVC2q5Qtig6dDGu",
-          "columnIds": [
-            "f-aM0W8UR1yHFh10nodyV"
-          ],
-          "x": 1239.1388,
-          "y": 466.5927,
-          "direction": 1
-        },
-        "meta": {
-          "updateAt": 1752123384187,
-          "createAt": 1752123384187
-        }
-      },
       "D93xB00L91sbgt4D7sq9M": {
         "id": "D93xB00L91sbgt4D7sq9M",
         "identification": false,
@@ -2736,8 +2292,8 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1545.2297000000003,
-          "y": 549.7291,
+          "x": 1559.7297000000003,
+          "y": 573.7291,
           "direction": 8
         },
         "end": {
@@ -2764,8 +2320,8 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1340.4297000000001,
-          "y": 549.7291,
+          "x": 1343.3297000000002,
+          "y": 573.7291,
           "direction": 8
         },
         "end": {
@@ -2792,8 +2348,8 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1442.8297000000002,
-          "y": 549.7291,
+          "x": 1451.5297000000003,
+          "y": 573.7291,
           "direction": 8
         },
         "end": {
@@ -2820,8 +2376,8 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1647.6297000000004,
-          "y": 549.7291,
+          "x": 1667.9297000000004,
+          "y": 573.7291,
           "direction": 8
         },
         "end": {
@@ -2848,8 +2404,8 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1750.0297000000005,
-          "y": 549.7291,
+          "x": 1776.1297000000004,
+          "y": 573.7291,
           "direction": 8
         },
         "end": {
@@ -2864,62 +2420,6 @@
         "meta": {
           "updateAt": 1752129636603,
           "createAt": 1752129636603
-        }
-      },
-      "EvLclSg00jda9RnRNGxzY": {
-        "id": "EvLclSg00jda9RnRNGxzY",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "M98IyDSU7ob4spyji_LWS",
-          "columnIds": [
-            "uPC2xJQDjEXYLzF4Jgl9C"
-          ],
-          "x": 560.4445,
-          "y": 982.6666,
-          "direction": 2
-        },
-        "end": {
-          "tableId": "WrKJrit6zGutAjdlQ5e8X",
-          "columnIds": [
-            "oUvQV6dHP7XQBq6KwwlwY"
-          ],
-          "x": 607.3478,
-          "y": 1184.4347,
-          "direction": 4
-        },
-        "meta": {
-          "updateAt": 1752219406164,
-          "createAt": 1752219406164
-        }
-      },
-      "_fEjO2v0-2LhqxsNfj0OU": {
-        "id": "_fEjO2v0-2LhqxsNfj0OU",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "M98IyDSU7ob4spyji_LWS",
-          "columnIds": [
-            "uPC2xJQDjEXYLzF4Jgl9C"
-          ],
-          "x": 302.9445,
-          "y": 1032.6666,
-          "direction": 8
-        },
-        "end": {
-          "tableId": "oYgEYkx0-sM1-Bw27sM6B",
-          "columnIds": [
-            "MxtTCSlbg5AXeXygX7yKZ"
-          ],
-          "x": 262,
-          "y": 1513,
-          "direction": 4
-        },
-        "meta": {
-          "updateAt": 1752219695446,
-          "createAt": 1752219695446
         }
       },
       "QQ33vOPy8SW0T1qr0FeDB": {
@@ -2961,7 +2461,7 @@
             "SndfoACEixcnnO8PtUcQJ"
           ],
           "x": 1289.2297,
-          "y": 305.7291,
+          "y": 317.7291,
           "direction": 1
         },
         "end": {
@@ -2982,22 +2482,6 @@
     "indexEntities": {},
     "indexColumnEntities": {},
     "memoEntities": {
-      "Rwy3Ef778V17qVSVlJYPq": {
-        "id": "Rwy3Ef778V17qVSVlJYPq",
-        "value": "깃허브 내부에서 관리하는 유저 정보는 다음 3가지\n{\n  \"login\": \"octocat\",\n  \"id\": 583231,\n  \"name\": \"The Octocat\",\n}\n\n이 중에서 id만 고유하고 나머지는 변경될 수 있기 때문에 무결성을 위해서 모든 테이블에서는 id를 FK로 참조하고 username이 필요하다면 Github_account 테이블과 join을 통해 가져올 것!",
-        "ui": {
-          "x": 401.4444,
-          "y": 597.3333,
-          "zIndex": 228,
-          "width": 349,
-          "height": 170,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1752219203986,
-          "createAt": 1752124517614
-        }
-      },
       "J68we_lGTznnMLZDKoIvF": {
         "id": "J68we_lGTznnMLZDKoIvF",
         "value": "정규화를 위해서 여러명이 기여했지만 레포는 하나만 저장하고,\n조인 테이블을 이용해서 계정과 N:N관계 유지",

--- a/sosd-backend/docs/github_schema.erd.json
+++ b/sosd-backend/docs/github_schema.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 2000,
     "height": 2000,
-    "scrollTop": 0,
-    "scrollLeft": -800,
-    "zoomLevel": 1,
+    "scrollTop": -295.4507,
+    "scrollLeft": -497.9534,
+    "zoomLevel": 0.76,
     "show": 495,
     "database": 4,
     "databaseName": "",
@@ -389,8 +389,7 @@
         "columnIds": [
           "ODv8w5x3x2vGpcQ69iwcy",
           "3Iq0fSMTpUpBRSzTOG14_",
-          "y4kue9YlcLC9VM7BOS4Ry",
-          "mf3o6sYMSWPL8aPIci0Ea"
+          "y4kue9YlcLC9VM7BOS4Ry"
         ],
         "seqColumnIds": [
           "ODv8w5x3x2vGpcQ69iwcy",
@@ -407,7 +406,7 @@
           "color": ""
         },
         "meta": {
-          "updateAt": 1754964867782,
+          "updateAt": 1755149388989,
           "createAt": 1754964385838
         }
       },
@@ -2442,7 +2441,7 @@
             "3Iq0fSMTpUpBRSzTOG14_"
           ],
           "x": 635,
-          "y": 306,
+          "y": 294,
           "direction": 1
         },
         "meta": {
@@ -2470,7 +2469,7 @@
             "y4kue9YlcLC9VM7BOS4Ry"
           ],
           "x": 1141,
-          "y": 306,
+          "y": 294,
           "direction": 2
         },
         "meta": {

--- a/sosd-backend/docs/github_schema.erd.json
+++ b/sosd-backend/docs/github_schema.erd.json
@@ -1,0 +1,3035 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dineug/erd-editor/main/json-schema/schema.json",
+  "version": "3.0.0",
+  "settings": {
+    "width": 2000,
+    "height": 2000,
+    "scrollTop": -680.2953,
+    "scrollLeft": -800,
+    "zoomLevel": 0.82,
+    "show": 495,
+    "database": 4,
+    "databaseName": "",
+    "canvasType": "ERD",
+    "language": 1,
+    "tableNameCase": 4,
+    "columnNameCase": 2,
+    "bracketType": 1,
+    "relationshipDataTypeSync": true,
+    "relationshipOptimization": false,
+    "columnOrder": [
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64
+    ],
+    "maxWidthComment": -1,
+    "ignoreSaveSettings": 0
+  },
+  "doc": {
+    "tableIds": [
+      "1da5rkmF4UyMqKlWtJp43",
+      "M98IyDSU7ob4spyji_LWS",
+      "tGokp1AVC2q5Qtig6dDGu",
+      "oR066qCWPc9vOFCxpoHVl",
+      "Wn5S9dcex38_Ns5BnGnWf",
+      "393ygiue4eRpi6k0hh9s-",
+      "0zxLl9nDGiwLcUDfG_76z",
+      "tMWjzTM-_8N9H0y1dtpXu",
+      "SSx8AS1rDk2wnLrBbaKFz"
+    ],
+    "relationshipIds": [
+      "TeYLqAdbWazR_Xc7ABHZi",
+      "D93xB00L91sbgt4D7sq9M",
+      "GmRjesxQENagJZvevu2gd",
+      "RJCYsX07OcBuMXYphZ3gZ",
+      "YBicdYW5cRtc31noK7_b8",
+      "Y6z6f3PMaEj3rJPnrmhwo",
+      "QQ33vOPy8SW0T1qr0FeDB",
+      "EAc14BCyNZeNfqDgA1Qba"
+    ],
+    "indexIds": [],
+    "memoIds": [
+      "J68we_lGTznnMLZDKoIvF",
+      "XZ2R-MeDFlwNtyzlc2-iJ"
+    ]
+  },
+  "collections": {
+    "tableEntities": {
+      "1da5rkmF4UyMqKlWtJp43": {
+        "id": "1da5rkmF4UyMqKlWtJp43",
+        "name": "User_account",
+        "comment": "유저 정보",
+        "columnIds": [
+          "rorIeLTinZV_ZnFEUfklH",
+          "EfFoMlVND23hXBeXQMQ7e",
+          "BHTqudZiO_M7pOtryD-Xe",
+          "YWtHoA8RWj9gjwULKTLqX",
+          "PFQ3Q7SHM7PxfQlGshm9j",
+          "r35oA9jhfjWiTuUzifF_-",
+          "eX-DNPJragh2yFxQhkIuS",
+          "q8je-SROzz6wkiUrchsQo",
+          "XphOZxUFoOYy3-jyib5us",
+          "pO5HiB47oIEb0Sir9tWvJ",
+          "avUR7xHU4Lsk6l5Uofzjq"
+        ],
+        "seqColumnIds": [
+          "rorIeLTinZV_ZnFEUfklH",
+          "EfFoMlVND23hXBeXQMQ7e",
+          "BHTqudZiO_M7pOtryD-Xe",
+          "YWtHoA8RWj9gjwULKTLqX",
+          "PFQ3Q7SHM7PxfQlGshm9j",
+          "r35oA9jhfjWiTuUzifF_-",
+          "eX-DNPJragh2yFxQhkIuS",
+          "q8je-SROzz6wkiUrchsQo",
+          "XphOZxUFoOYy3-jyib5us",
+          "pO5HiB47oIEb0Sir9tWvJ",
+          "avUR7xHU4Lsk6l5Uofzjq"
+        ],
+        "ui": {
+          "x": 61,
+          "y": 221,
+          "zIndex": 2,
+          "widthName": 73,
+          "widthComment": 60,
+          "color": "#03A9F4"
+        },
+        "meta": {
+          "updateAt": 1752220113728,
+          "createAt": 1752122901510
+        }
+      },
+      "M98IyDSU7ob4spyji_LWS": {
+        "id": "M98IyDSU7ob4spyji_LWS",
+        "name": "Github_account",
+        "comment": "깃허브 계정",
+        "columnIds": [
+          "uPC2xJQDjEXYLzF4Jgl9C",
+          "HDc528cIZPglN0kMlWH5E",
+          "fvtC-OuKzazRvbfiOAq_N",
+          "l531zWOy6KYIh6kzlagqL",
+          "vFFe92UsUePq8Z7Ej6ftm",
+          "eemFw7IyKy_OkTvev2mCO"
+        ],
+        "seqColumnIds": [
+          "uPC2xJQDjEXYLzF4Jgl9C",
+          "HDc528cIZPglN0kMlWH5E",
+          "fvtC-OuKzazRvbfiOAq_N",
+          "l531zWOy6KYIh6kzlagqL",
+          "vFFe92UsUePq8Z7Ej6ftm",
+          "eemFw7IyKy_OkTvev2mCO"
+        ],
+        "ui": {
+          "x": 45.4445,
+          "y": 832.6666,
+          "zIndex": 69,
+          "widthName": 85,
+          "widthComment": 65,
+          "color": "#03A9F4"
+        },
+        "meta": {
+          "updateAt": 1752220113728,
+          "createAt": 1752123099069
+        }
+      },
+      "tGokp1AVC2q5Qtig6dDGu": {
+        "id": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "github_repository",
+        "comment": "깃허브 레포 정보",
+        "columnIds": [
+          "SndfoACEixcnnO8PtUcQJ",
+          "caM1MHVviEIFb7HRrWply",
+          "BjiYJyFwdfJF5gTftMGe1",
+          "8WSsAoHi8ACqNJgfcz7SG",
+          "iA57Gyx6CzHwbWiM4WpAP",
+          "wDrs0YXAC5SFvxes7GsQI",
+          "nl9eQSxuHUTNevvNx0Dzj",
+          "1zCfN75JBZopqDSM9ezeC",
+          "fWi4uZK0OMixiw_Vk_-hu",
+          "XXVElj94n5rtSXLyyQM-o",
+          "w6jGHQyeRpmsjZyTuv-4e",
+          "1gac-DySAs1_bsEuPhgM2",
+          "FcO6AlIDb-wabf7rZN5ny",
+          "dYosxFHh6LcJUgg06bhLO",
+          "mQFXIk1deHsl3s3mwS_iK",
+          "zjok5tKh5bbSUEKVo6ExH",
+          "C8_O2YpT1nzXd5dNGIcu-",
+          "uBavAwcvoGuLrO1oPEH1i"
+        ],
+        "seqColumnIds": [
+          "SndfoACEixcnnO8PtUcQJ",
+          "f-aM0W8UR1yHFh10nodyV",
+          "kIQzYnZ0ePIPY0Pv5UQvC",
+          "caM1MHVviEIFb7HRrWply",
+          "BjiYJyFwdfJF5gTftMGe1",
+          "8WSsAoHi8ACqNJgfcz7SG",
+          "iA57Gyx6CzHwbWiM4WpAP",
+          "wDrs0YXAC5SFvxes7GsQI",
+          "gszg0PiPncxiDKJAAN9mc",
+          "nl9eQSxuHUTNevvNx0Dzj",
+          "1zCfN75JBZopqDSM9ezeC",
+          "fWi4uZK0OMixiw_Vk_-hu",
+          "Tkbr_ROvA4ooNlPguU1RD",
+          "djt-D1qpO8B-I950qXHNr",
+          "WIfXJhKqdEH0PRh6hG8el",
+          "CDVv-jt_usMaaE9ALWh70",
+          "hZARCVqk90iOTqno46DJo",
+          "CWbbB4YfWctrUPrtu5UHD",
+          "faPPSCOogg7Ca5wyneUpV",
+          "u8ayETK9wl4viwzyFTNc5",
+          "24cwIf1CpUdCPwjAikx69",
+          "hmVOdMuSLphRm1wDkYZSL",
+          "XXVElj94n5rtSXLyyQM-o",
+          "w6jGHQyeRpmsjZyTuv-4e",
+          "1gac-DySAs1_bsEuPhgM2",
+          "FcO6AlIDb-wabf7rZN5ny",
+          "dYosxFHh6LcJUgg06bhLO",
+          "mQFXIk1deHsl3s3mwS_iK",
+          "zjok5tKh5bbSUEKVo6ExH",
+          "C8_O2YpT1nzXd5dNGIcu-",
+          "uBavAwcvoGuLrO1oPEH1i"
+        ],
+        "ui": {
+          "x": 1289.2297,
+          "y": 61.7291,
+          "zIndex": 105,
+          "widthName": 95,
+          "widthComment": 93,
+          "color": "#FF5722"
+        },
+        "meta": {
+          "updateAt": 1754964511102,
+          "createAt": 1752123292288
+        }
+      },
+      "oR066qCWPc9vOFCxpoHVl": {
+        "id": "oR066qCWPc9vOFCxpoHVl",
+        "name": "github_commit",
+        "comment": "커밋 테이블",
+        "columnIds": [
+          "pxLMtSz99u9cp9EvA5Z0v",
+          "RsdNjvGgwKY29CdgZSnOu",
+          "er2070jOcelBfevEblTnq",
+          "_jzBsJ8RiigmJhtWsbo2D",
+          "B-PzZ4KiiW2z5DvvrBJRc",
+          "M6I0ID1UrSUARTa-X6xXy",
+          "EsHf2tsGwhhR-m2rd-trY",
+          "G_R09VpNc_Rmtxe2EcNnA",
+          "zkTiiQIbMegcxLLWUVBnL"
+        ],
+        "seqColumnIds": [
+          "pxLMtSz99u9cp9EvA5Z0v",
+          "kXBakSdPvvokX9ZYSzrWc",
+          "RsdNjvGgwKY29CdgZSnOu",
+          "qw0z1Kviz6KtIBk1FzYHH",
+          "er2070jOcelBfevEblTnq",
+          "_jzBsJ8RiigmJhtWsbo2D",
+          "B-PzZ4KiiW2z5DvvrBJRc",
+          "8tKOPHJ-G54VO3eH1DGyT",
+          "M6I0ID1UrSUARTa-X6xXy",
+          "EsHf2tsGwhhR-m2rd-trY",
+          "G_R09VpNc_Rmtxe2EcNnA",
+          "zkTiiQIbMegcxLLWUVBnL"
+        ],
+        "ui": {
+          "x": 717.1676,
+          "y": 726.8226,
+          "zIndex": 288,
+          "widthName": 82,
+          "widthComment": 65,
+          "color": "#FF5722"
+        },
+        "meta": {
+          "updateAt": 1754964563945,
+          "createAt": 1752126837858
+        }
+      },
+      "Wn5S9dcex38_Ns5BnGnWf": {
+        "id": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "github_pr",
+        "comment": "pr 테이블",
+        "columnIds": [
+          "xbhjUV-f6eAGQluOf8ytD",
+          "PUkg1w0g_yUvchf_S09Uy",
+          "iwtkkvMPk9w-0sc6cB0YJ",
+          "vuJcTXnLQcT0i1ZT2MRg_",
+          "oJD1Hm_jdqxbjTAPsPFRu",
+          "WC0I-MfQGqCK3uGlw3kn6",
+          "ZZC7G_9Xxj2gUHFeo4mWO",
+          "cLG6v8mC1ahtR_QS9hBN0",
+          "aAsMdWBNM2HCoZ9Rtyvmp"
+        ],
+        "seqColumnIds": [
+          "xbhjUV-f6eAGQluOf8ytD",
+          "PUkg1w0g_yUvchf_S09Uy",
+          "iwtkkvMPk9w-0sc6cB0YJ",
+          "369BdaQiL7k1upMnJ5zQP",
+          "vuJcTXnLQcT0i1ZT2MRg_",
+          "oJD1Hm_jdqxbjTAPsPFRu",
+          "WC0I-MfQGqCK3uGlw3kn6",
+          "ZZC7G_9Xxj2gUHFeo4mWO",
+          "cLG6v8mC1ahtR_QS9hBN0",
+          "aAsMdWBNM2HCoZ9Rtyvmp",
+          "6GeoH3XtnCbQcjwhSu1t2"
+        ],
+        "ui": {
+          "x": 647.706,
+          "y": 1124.3322,
+          "zIndex": 384,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": "#F44336"
+        },
+        "meta": {
+          "updateAt": 1754964639482,
+          "createAt": 1752128937791
+        }
+      },
+      "393ygiue4eRpi6k0hh9s-": {
+        "id": "393ygiue4eRpi6k0hh9s-",
+        "name": "github_issue",
+        "comment": "issue 테이블",
+        "columnIds": [
+          "DabssjAYD1fDVj6nmk8vt",
+          "snQEnCtCZuqyR0__Wefbh",
+          "9cdIz-_SgYQUEkt7b-r71",
+          "_Gnp4bRvqMJODi2C3THdn",
+          "MrSvpfYTMbMeHjNII1tWg",
+          "FyzXkR2VsESukbAq0mYbg"
+        ],
+        "seqColumnIds": [
+          "DabssjAYD1fDVj6nmk8vt",
+          "snQEnCtCZuqyR0__Wefbh",
+          "dpBgCy5FkFs-ErF6XdK_t",
+          "9cdIz-_SgYQUEkt7b-r71",
+          "_Gnp4bRvqMJODi2C3THdn",
+          "MrSvpfYTMbMeHjNII1tWg",
+          "FyzXkR2VsESukbAq0mYbg"
+        ],
+        "ui": {
+          "x": 649.2862,
+          "y": 1482.7949,
+          "zIndex": 460,
+          "widthName": 68,
+          "widthComment": 67,
+          "color": "#F44336"
+        },
+        "meta": {
+          "updateAt": 1754964637600,
+          "createAt": 1752129204487
+        }
+      },
+      "0zxLl9nDGiwLcUDfG_76z": {
+        "id": "0zxLl9nDGiwLcUDfG_76z",
+        "name": "github_star",
+        "comment": "star 테이블",
+        "columnIds": [
+          "hHmDaHZAau4mJg66jNhUj",
+          "R9d-yI0dFWdxk9KB4ut-G",
+          "eccdGJYy06mX4t65btipC",
+          "LA_x9K1YZ1TA8Vm4PVgYs"
+        ],
+        "seqColumnIds": [
+          "hHmDaHZAau4mJg66jNhUj",
+          "R9d-yI0dFWdxk9KB4ut-G",
+          "eccdGJYy06mX4t65btipC",
+          "LA_x9K1YZ1TA8Vm4PVgYs"
+        ],
+        "ui": {
+          "x": 1264.1054,
+          "y": 1310.8703,
+          "zIndex": 511,
+          "widthName": 61,
+          "widthComment": 61,
+          "color": "#F44336"
+        },
+        "meta": {
+          "updateAt": 1754964656242,
+          "createAt": 1752129499267
+        }
+      },
+      "tMWjzTM-_8N9H0y1dtpXu": {
+        "id": "tMWjzTM-_8N9H0y1dtpXu",
+        "name": "github_fork",
+        "comment": "fork 테이블",
+        "columnIds": [
+          "Bh_0TPIFf01FOy0By9eDS",
+          "_GXwWR21WdgBAcggabZJw",
+          "mWKwnKzQhNIlxRMx9BSb7",
+          "dqznT5eYeP0slM9v4LxGC"
+        ],
+        "seqColumnIds": [
+          "Bh_0TPIFf01FOy0By9eDS",
+          "_GXwWR21WdgBAcggabZJw",
+          "mWKwnKzQhNIlxRMx9BSb7",
+          "dqznT5eYeP0slM9v4LxGC"
+        ],
+        "ui": {
+          "x": 1411.2771,
+          "y": 1556.2694,
+          "zIndex": 545,
+          "widthName": 63,
+          "widthComment": 62,
+          "color": "#F44336"
+        },
+        "meta": {
+          "updateAt": 1754964714715,
+          "createAt": 1752129592485
+        }
+      },
+      "WrKJrit6zGutAjdlQ5e8X": {
+        "id": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "github_total_data",
+        "comment": "연도별 총 통계량(default branch만 반영)",
+        "columnIds": [
+          "T2qVY3i5JTAe-qUBiElRL",
+          "oUvQV6dHP7XQBq6KwwlwY",
+          "oDQxwfdiSLB-ZM-k_5P26",
+          "75XLyJyGqwOSiybJIVmLZ",
+          "adkbRhJ6Zc_ekqPnu7JTQ",
+          "LtnzqCEdOaqcAfrNFJGl_",
+          "7FLDoibJHUnbQMR34kSu2",
+          "e3bv6nSpf4L65cztwt6of",
+          "sNlLpOcAsLU_ZR8qaLfMz",
+          "GLqibB1L4E7y7YKFUF_BI"
+        ],
+        "seqColumnIds": [
+          "T2qVY3i5JTAe-qUBiElRL",
+          "oUvQV6dHP7XQBq6KwwlwY",
+          "oDQxwfdiSLB-ZM-k_5P26",
+          "75XLyJyGqwOSiybJIVmLZ",
+          "adkbRhJ6Zc_ekqPnu7JTQ",
+          "LtnzqCEdOaqcAfrNFJGl_",
+          "7FLDoibJHUnbQMR34kSu2",
+          "e3bv6nSpf4L65cztwt6of",
+          "sNlLpOcAsLU_ZR8qaLfMz",
+          "GLqibB1L4E7y7YKFUF_BI"
+        ],
+        "ui": {
+          "x": 367.3478,
+          "y": 1184.4347,
+          "zIndex": 786,
+          "widthName": 94,
+          "widthComment": 216,
+          "color": "#4CAF50"
+        },
+        "meta": {
+          "updateAt": 1752220113728,
+          "createAt": 1752219329055
+        }
+      },
+      "oYgEYkx0-sM1-Bw27sM6B": {
+        "id": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "github_score",
+        "comment": "",
+        "columnIds": [
+          "UlWidgU8sM_Vf6_2JJ-sU",
+          "MxtTCSlbg5AXeXygX7yKZ",
+          "SHtwCkTTl_Hi5shN8iVHC",
+          "4uxsfjUz3RNN0Qmmp4UyC",
+          "l7myLScWLmOOCQURO4M9G",
+          "Zupd_yM9fwxxJpus3SC2I",
+          "h4sHCSW23Cx251ytQM8YK",
+          "Vt9RMvYJwx8pnRZQTXXDS"
+        ],
+        "seqColumnIds": [
+          "UlWidgU8sM_Vf6_2JJ-sU",
+          "MxtTCSlbg5AXeXygX7yKZ",
+          "SHtwCkTTl_Hi5shN8iVHC",
+          "4uxsfjUz3RNN0Qmmp4UyC",
+          "l7myLScWLmOOCQURO4M9G",
+          "Zupd_yM9fwxxJpus3SC2I",
+          "h4sHCSW23Cx251ytQM8YK",
+          "Vt9RMvYJwx8pnRZQTXXDS"
+        ],
+        "ui": {
+          "x": -4,
+          "y": 1513,
+          "zIndex": 854,
+          "widthName": 70,
+          "widthComment": 60,
+          "color": "#4CAF50"
+        },
+        "meta": {
+          "updateAt": 1752220113728,
+          "createAt": 1752219521962
+        }
+      },
+      "SSx8AS1rDk2wnLrBbaKFz": {
+        "id": "SSx8AS1rDk2wnLrBbaKFz",
+        "name": "github_account_repository",
+        "comment": "깃허브 계정 - 레포 조인테이블",
+        "columnIds": [
+          "ODv8w5x3x2vGpcQ69iwcy",
+          "3Iq0fSMTpUpBRSzTOG14_",
+          "y4kue9YlcLC9VM7BOS4Ry",
+          "mf3o6sYMSWPL8aPIci0Ea"
+        ],
+        "seqColumnIds": [
+          "ODv8w5x3x2vGpcQ69iwcy",
+          "3Iq0fSMTpUpBRSzTOG14_",
+          "y4kue9YlcLC9VM7BOS4Ry",
+          "mf3o6sYMSWPL8aPIci0Ea"
+        ],
+        "ui": {
+          "x": 635,
+          "y": 230,
+          "zIndex": 558,
+          "widthName": 142,
+          "widthComment": 164,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1754964867782,
+          "createAt": 1754964385838
+        }
+      },
+      "fFPSkUkSrpAZMn0fIe3Sg": {
+        "id": "fFPSkUkSrpAZMn0fIe3Sg",
+        "name": "",
+        "comment": "",
+        "columnIds": [],
+        "seqColumnIds": [],
+        "ui": {
+          "x": 200,
+          "y": 353,
+          "zIndex": 596,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1754964961295,
+          "createAt": 1754964961295
+        }
+      }
+    },
+    "tableColumnEntities": {
+      "rorIeLTinZV_ZnFEUfklH": {
+        "id": "rorIeLTinZV_ZnFEUfklH",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "student_id",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752122951144,
+          "createAt": 1752122922313
+        }
+      },
+      "EfFoMlVND23hXBeXQMQ7e": {
+        "id": "EfFoMlVND23hXBeXQMQ7e",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "date_joined",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123015378,
+          "createAt": 1752122936727
+        }
+      },
+      "BHTqudZiO_M7pOtryD-Xe": {
+        "id": "BHTqudZiO_M7pOtryD-Xe",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "role",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123022855,
+          "createAt": 1752123020928
+        }
+      },
+      "YWtHoA8RWj9gjwULKTLqX": {
+        "id": "YWtHoA8RWj9gjwULKTLqX",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "name",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123035062,
+          "createAt": 1752123025815
+        }
+      },
+      "PFQ3Q7SHM7PxfQlGshm9j": {
+        "id": "PFQ3Q7SHM7PxfQlGshm9j",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "college",
+        "comment": "대학",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123653522,
+          "createAt": 1752123036264
+        }
+      },
+      "r35oA9jhfjWiTuUzifF_-": {
+        "id": "r35oA9jhfjWiTuUzifF_-",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "dept",
+        "comment": "학과",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123655153,
+          "createAt": 1752123040880
+        }
+      },
+      "eX-DNPJragh2yFxQhkIuS": {
+        "id": "eX-DNPJragh2yFxQhkIuS",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "last_login",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123054761,
+          "createAt": 1752123049978
+        }
+      },
+      "q8je-SROzz6wkiUrchsQo": {
+        "id": "q8je-SROzz6wkiUrchsQo",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "is_active",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123061013,
+          "createAt": 1752123055964
+        }
+      },
+      "XphOZxUFoOYy3-jyib5us": {
+        "id": "XphOZxUFoOYy3-jyib5us",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "photo",
+        "comment": "프로필 사진",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123646515,
+          "createAt": 1752123062697
+        }
+      },
+      "pO5HiB47oIEb0Sir9tWvJ": {
+        "id": "pO5HiB47oIEb0Sir9tWvJ",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "introduction",
+        "comment": "소개글",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123649053,
+          "createAt": 1752123068567
+        }
+      },
+      "avUR7xHU4Lsk6l5Uofzjq": {
+        "id": "avUR7xHU4Lsk6l5Uofzjq",
+        "tableId": "1da5rkmF4UyMqKlWtJp43",
+        "name": "portfolio",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123087393,
+          "createAt": 1752123076199
+        }
+      },
+      "HDc528cIZPglN0kMlWH5E": {
+        "id": "HDc528cIZPglN0kMlWH5E",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "student_id",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123128476,
+          "createAt": 1752123128476
+        }
+      },
+      "uPC2xJQDjEXYLzF4Jgl9C": {
+        "id": "uPC2xJQDjEXYLzF4Jgl9C",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "github_id",
+        "comment": "깃허브에서 제공하는 Id",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 127,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129091353,
+          "createAt": 1752123140619
+        }
+      },
+      "vFFe92UsUePq8Z7Ej6ftm": {
+        "id": "vFFe92UsUePq8Z7Ej6ftm",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "github_token",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 72,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123175715,
+          "createAt": 1752123160734
+        }
+      },
+      "eemFw7IyKy_OkTvev2mCO": {
+        "id": "eemFw7IyKy_OkTvev2mCO",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "last_crawling",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752123204823,
+          "createAt": 1752123176921
+        }
+      },
+      "f-aM0W8UR1yHFh10nodyV": {
+        "id": "f-aM0W8UR1yHFh10nodyV",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "github_id",
+        "comment": "UK1",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129036479,
+          "createAt": 1752123384187
+        }
+      },
+      "SndfoACEixcnnO8PtUcQJ": {
+        "id": "SndfoACEixcnnO8PtUcQJ",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964735380,
+          "createAt": 1752123407926
+        }
+      },
+      "BjiYJyFwdfJF5gTftMGe1": {
+        "id": "BjiYJyFwdfJF5gTftMGe1",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "owner_name",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964522472,
+          "createAt": 1752123420245
+        }
+      },
+      "8WSsAoHi8ACqNJgfcz7SG": {
+        "id": "8WSsAoHi8ACqNJgfcz7SG",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "repo_name",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964525118,
+          "createAt": 1752123454413
+        }
+      },
+      "fvtC-OuKzazRvbfiOAq_N": {
+        "id": "fvtC-OuKzazRvbfiOAq_N",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "github_login",
+        "comment": "username(ex. byungKHee)",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 4,
+        "ui": {
+          "keys": 0,
+          "widthName": 68,
+          "widthComment": 140,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752124442728,
+          "createAt": 1752124251704
+        }
+      },
+      "l531zWOy6KYIh6kzlagqL": {
+        "id": "l531zWOy6KYIh6kzlagqL",
+        "tableId": "M98IyDSU7ob4spyji_LWS",
+        "name": "github_name",
+        "comment": "github profile name(ex. 강병희)",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 71,
+          "widthComment": 168,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752126596162,
+          "createAt": 1752124261386
+        }
+      },
+      "kIQzYnZ0ePIPY0Pv5UQvC": {
+        "id": "kIQzYnZ0ePIPY0Pv5UQvC",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "github_login",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 72,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752124451571,
+          "createAt": 1752124445092
+        }
+      },
+      "nl9eQSxuHUTNevvNx0Dzj": {
+        "id": "nl9eQSxuHUTNevvNx0Dzj",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "watcher",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752125352792,
+          "createAt": 1752125211519
+        }
+      },
+      "1zCfN75JBZopqDSM9ezeC": {
+        "id": "1zCfN75JBZopqDSM9ezeC",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "star",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752125354159,
+          "createAt": 1752125223691
+        }
+      },
+      "fWi4uZK0OMixiw_Vk_-hu": {
+        "id": "fWi4uZK0OMixiw_Vk_-hu",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "fork",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752125355339,
+          "createAt": 1752125223822
+        }
+      },
+      "Tkbr_ROvA4ooNlPguU1RD": {
+        "id": "Tkbr_ROvA4ooNlPguU1RD",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "commit_count",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 77,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219963597,
+          "createAt": 1752125223940
+        }
+      },
+      "djt-D1qpO8B-I950qXHNr": {
+        "id": "djt-D1qpO8B-I950qXHNr",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "commit_line",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 66,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219965462,
+          "createAt": 1752125224072
+        }
+      },
+      "WIfXJhKqdEH0PRh6hG8el": {
+        "id": "WIfXJhKqdEH0PRh6hG8el",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "commit_del",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219968038,
+          "createAt": 1752125224171
+        }
+      },
+      "CDVv-jt_usMaaE9ALWh70": {
+        "id": "CDVv-jt_usMaaE9ALWh70",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "commit_add",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219969422,
+          "createAt": 1752125299792
+        }
+      },
+      "24cwIf1CpUdCPwjAikx69": {
+        "id": "24cwIf1CpUdCPwjAikx69",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "pr",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219972576,
+          "createAt": 1752125299909
+        }
+      },
+      "hmVOdMuSLphRm1wDkYZSL": {
+        "id": "hmVOdMuSLphRm1wDkYZSL",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "issue",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219973955,
+          "createAt": 1752125300025
+        }
+      },
+      "XXVElj94n5rtSXLyyQM-o": {
+        "id": "XXVElj94n5rtSXLyyQM-o",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "dependency",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219987840,
+          "createAt": 1752125313526
+        }
+      },
+      "w6jGHQyeRpmsjZyTuv-4e": {
+        "id": "w6jGHQyeRpmsjZyTuv-4e",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "description",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219990422,
+          "createAt": 1752125377411
+        }
+      },
+      "1gac-DySAs1_bsEuPhgM2": {
+        "id": "1gac-DySAs1_bsEuPhgM2",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "readme",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752125385862,
+          "createAt": 1752125377538
+        }
+      },
+      "FcO6AlIDb-wabf7rZN5ny": {
+        "id": "FcO6AlIDb-wabf7rZN5ny",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "liscence",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220004069,
+          "createAt": 1752125377659
+        }
+      },
+      "dYosxFHh6LcJUgg06bhLO": {
+        "id": "dYosxFHh6LcJUgg06bhLO",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "commit_date",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 71,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220006406,
+          "createAt": 1752125377760
+        }
+      },
+      "mQFXIk1deHsl3s3mwS_iK": {
+        "id": "mQFXIk1deHsl3s3mwS_iK",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "update_date",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220007968,
+          "createAt": 1752125392196
+        }
+      },
+      "zjok5tKh5bbSUEKVo6ExH": {
+        "id": "zjok5tKh5bbSUEKVo6ExH",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "created_date",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 70,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220009593,
+          "createAt": 1752125392342
+        }
+      },
+      "C8_O2YpT1nzXd5dNGIcu-": {
+        "id": "C8_O2YpT1nzXd5dNGIcu-",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "contributor",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220013634,
+          "createAt": 1752125392460
+        }
+      },
+      "uBavAwcvoGuLrO1oPEH1i": {
+        "id": "uBavAwcvoGuLrO1oPEH1i",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "is_private",
+        "comment": "",
+        "dataType": "BOOLEAN",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220017796,
+          "createAt": 1752125423698
+        }
+      },
+      "gszg0PiPncxiDKJAAN9mc": {
+        "id": "gszg0PiPncxiDKJAAN9mc",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "score",
+        "comment": "레포별 점수",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752126704822,
+          "createAt": 1752126691719
+        }
+      },
+      "er2070jOcelBfevEblTnq": {
+        "id": "er2070jOcelBfevEblTnq",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "sha",
+        "comment": "깃허브 고유 해시번호",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 117,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964563218,
+          "createAt": 1752126860327
+        }
+      },
+      "kXBakSdPvvokX9ZYSzrWc": {
+        "id": "kXBakSdPvvokX9ZYSzrWc",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752126926179,
+          "createAt": 1752126926179
+        }
+      },
+      "RsdNjvGgwKY29CdgZSnOu": {
+        "id": "RsdNjvGgwKY29CdgZSnOu",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964755501,
+          "createAt": 1752126938939
+        }
+      },
+      "_jzBsJ8RiigmJhtWsbo2D": {
+        "id": "_jzBsJ8RiigmJhtWsbo2D",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "addition",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128095476,
+          "createAt": 1752127028164
+        }
+      },
+      "B-PzZ4KiiW2z5DvvrBJRc": {
+        "id": "B-PzZ4KiiW2z5DvvrBJRc",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "deletion",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128104202,
+          "createAt": 1752128100111
+        }
+      },
+      "M6I0ID1UrSUARTa-X6xXy": {
+        "id": "M6I0ID1UrSUARTa-X6xXy",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "author_date",
+        "comment": "커밋 작성 시간",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 65,
+          "widthComment": 81,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128532278,
+          "createAt": 1752128105461
+        }
+      },
+      "EsHf2tsGwhhR-m2rd-trY": {
+        "id": "EsHf2tsGwhhR-m2rd-trY",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "committer_date",
+        "comment": "푸시한 시간",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 85,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128543969,
+          "createAt": 1752128533778
+        }
+      },
+      "8tKOPHJ-G54VO3eH1DGyT": {
+        "id": "8tKOPHJ-G54VO3eH1DGyT",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128729156,
+          "createAt": 1752128698700
+        }
+      },
+      "qw0z1Kviz6KtIBk1FzYHH": {
+        "id": "qw0z1Kviz6KtIBk1FzYHH",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "author_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129036479,
+          "createAt": 1752128723663
+        }
+      },
+      "G_R09VpNc_Rmtxe2EcNnA": {
+        "id": "G_R09VpNc_Rmtxe2EcNnA",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "message",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752128825882,
+          "createAt": 1752128822770
+        }
+      },
+      "369BdaQiL7k1upMnJ5zQP": {
+        "id": "369BdaQiL7k1upMnJ5zQP",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "author_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129174486,
+          "createAt": 1752129067713
+        }
+      },
+      "iwtkkvMPk9w-0sc6cB0YJ": {
+        "id": "iwtkkvMPk9w-0sc6cB0YJ",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964643926,
+          "createAt": 1752129072742
+        }
+      },
+      "PUkg1w0g_yUvchf_S09Uy": {
+        "id": "PUkg1w0g_yUvchf_S09Uy",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "pr_id",
+        "comment": "깃허브에서 제공",
+        "dataType": "",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 89,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964589094,
+          "createAt": 1752129075619
+        }
+      },
+      "oJD1Hm_jdqxbjTAPsPFRu": {
+        "id": "oJD1Hm_jdqxbjTAPsPFRu",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "pr_title",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752218644898,
+          "createAt": 1752129180369
+        }
+      },
+      "WC0I-MfQGqCK3uGlw3kn6": {
+        "id": "WC0I-MfQGqCK3uGlw3kn6",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "pr_date",
+        "comment": "",
+        "dataType": "DATETIME",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129199536,
+          "createAt": 1752129188602
+        }
+      },
+      "dpBgCy5FkFs-ErF6XdK_t": {
+        "id": "dpBgCy5FkFs-ErF6XdK_t",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "author_id",
+        "comment": "깃허브에서 제공하는 Id",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 113,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129294626,
+          "createAt": 1752129227886
+        }
+      },
+      "9cdIz-_SgYQUEkt7b-r71": {
+        "id": "9cdIz-_SgYQUEkt7b-r71",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964627214,
+          "createAt": 1752129232156
+        }
+      },
+      "DabssjAYD1fDVj6nmk8vt": {
+        "id": "DabssjAYD1fDVj6nmk8vt",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964729765,
+          "createAt": 1752129278042
+        }
+      },
+      "MrSvpfYTMbMeHjNII1tWg": {
+        "id": "MrSvpfYTMbMeHjNII1tWg",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "issue_title",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129449837,
+          "createAt": 1752129443935
+        }
+      },
+      "FyzXkR2VsESukbAq0mYbg": {
+        "id": "FyzXkR2VsESukbAq0mYbg",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "issue_date",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129455983,
+          "createAt": 1752129451916
+        }
+      },
+      "R9d-yI0dFWdxk9KB4ut-G": {
+        "id": "R9d-yI0dFWdxk9KB4ut-G",
+        "tableId": "0zxLl9nDGiwLcUDfG_76z",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964707702,
+          "createAt": 1752129526693
+        }
+      },
+      "hHmDaHZAau4mJg66jNhUj": {
+        "id": "hHmDaHZAau4mJg66jNhUj",
+        "tableId": "0zxLl9nDGiwLcUDfG_76z",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964723521,
+          "createAt": 1752129533537
+        }
+      },
+      "eccdGJYy06mX4t65btipC": {
+        "id": "eccdGJYy06mX4t65btipC",
+        "tableId": "0zxLl9nDGiwLcUDfG_76z",
+        "name": "star_user_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 64,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964708038,
+          "createAt": 1752129574536
+        }
+      },
+      "LA_x9K1YZ1TA8Vm4PVgYs": {
+        "id": "LA_x9K1YZ1TA8Vm4PVgYs",
+        "tableId": "0zxLl9nDGiwLcUDfG_76z",
+        "name": "starrd_at",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129590167,
+          "createAt": 1752129583254
+        }
+      },
+      "Bh_0TPIFf01FOy0By9eDS": {
+        "id": "Bh_0TPIFf01FOy0By9eDS",
+        "tableId": "tMWjzTM-_8N9H0y1dtpXu",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964726707,
+          "createAt": 1752129620019
+        }
+      },
+      "_GXwWR21WdgBAcggabZJw": {
+        "id": "_GXwWR21WdgBAcggabZJw",
+        "tableId": "tMWjzTM-_8N9H0y1dtpXu",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964710086,
+          "createAt": 1752129636603
+        }
+      },
+      "mWKwnKzQhNIlxRMx9BSb7": {
+        "id": "mWKwnKzQhNIlxRMx9BSb7",
+        "tableId": "tMWjzTM-_8N9H0y1dtpXu",
+        "name": "fork_user_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 65,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964712381,
+          "createAt": 1752129669806
+        }
+      },
+      "dqznT5eYeP0slM9v4LxGC": {
+        "id": "dqznT5eYeP0slM9v4LxGC",
+        "tableId": "tMWjzTM-_8N9H0y1dtpXu",
+        "name": "forked_at",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752129704491,
+          "createAt": 1752129701921
+        }
+      },
+      "wDrs0YXAC5SFvxes7GsQI": {
+        "id": "wDrs0YXAC5SFvxes7GsQI",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "default_branch",
+        "comment": "점수를 반영하는 기준 브랜치",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 80,
+          "widthComment": 156,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752216396030,
+          "createAt": 1752216370953
+        }
+      },
+      "zkTiiQIbMegcxLLWUVBnL": {
+        "id": "zkTiiQIbMegcxLLWUVBnL",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "branch",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752216756957,
+          "createAt": 1752216418115
+        }
+      },
+      "cLG6v8mC1ahtR_QS9hBN0": {
+        "id": "cLG6v8mC1ahtR_QS9hBN0",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "base_branch",
+        "comment": "도착 브랜치",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 68,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752217078738,
+          "createAt": 1752216495380
+        }
+      },
+      "aAsMdWBNM2HCoZ9Rtyvmp": {
+        "id": "aAsMdWBNM2HCoZ9Rtyvmp",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "head_branch",
+        "comment": "출발 브랜치",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 70,
+          "widthComment": 65,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752217081375,
+          "createAt": 1752216499136
+        }
+      },
+      "6GeoH3XtnCbQcjwhSu1t2": {
+        "id": "6GeoH3XtnCbQcjwhSu1t2",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752216499268,
+          "createAt": 1752216499268
+        }
+      },
+      "ZZC7G_9Xxj2gUHFeo4mWO": {
+        "id": "ZZC7G_9Xxj2gUHFeo4mWO",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "merged",
+        "comment": "",
+        "dataType": "BOOLEAN",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752218352002,
+          "createAt": 1752218326196
+        }
+      },
+      "vuJcTXnLQcT0i1ZT2MRg_": {
+        "id": "vuJcTXnLQcT0i1ZT2MRg_",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "pr_number",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964594754,
+          "createAt": 1752218613165
+        }
+      },
+      "_Gnp4bRvqMJODi2C3THdn": {
+        "id": "_Gnp4bRvqMJODi2C3THdn",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "issue_number",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 75,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964629363,
+          "createAt": 1752218627265
+        }
+      },
+      "T2qVY3i5JTAe-qUBiElRL": {
+        "id": "T2qVY3i5JTAe-qUBiElRL",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "INT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219389250,
+          "createAt": 1752219370721
+        }
+      },
+      "oDQxwfdiSLB-ZM-k_5P26": {
+        "id": "oDQxwfdiSLB-ZM-k_5P26",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "year",
+        "comment": "github_id + year로 UQ1",
+        "dataType": "",
+        "default": "",
+        "options": 4,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 128,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219436899,
+          "createAt": 1752219391170
+        }
+      },
+      "oUvQV6dHP7XQBq6KwwlwY": {
+        "id": "oUvQV6dHP7XQBq6KwwlwY",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "github_id",
+        "comment": "깃허브에서 제공하는 Id",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 127,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219428140,
+          "createAt": 1752219406164
+        }
+      },
+      "75XLyJyGqwOSiybJIVmLZ": {
+        "id": "75XLyJyGqwOSiybJIVmLZ",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "commit_line",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 66,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219455721,
+          "createAt": 1752219440190
+        }
+      },
+      "adkbRhJ6Zc_ekqPnu7JTQ": {
+        "id": "adkbRhJ6Zc_ekqPnu7JTQ",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "commit_count",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 77,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219469189,
+          "createAt": 1752219458705
+        }
+      },
+      "LtnzqCEdOaqcAfrNFJGl_": {
+        "id": "LtnzqCEdOaqcAfrNFJGl_",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "pr_count",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219474560,
+          "createAt": 1752219472071
+        }
+      },
+      "7FLDoibJHUnbQMR34kSu2": {
+        "id": "7FLDoibJHUnbQMR34kSu2",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "issue_count",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219482089,
+          "createAt": 1752219475643
+        }
+      },
+      "e3bv6nSpf4L65cztwt6of": {
+        "id": "e3bv6nSpf4L65cztwt6of",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "star_count",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219487626,
+          "createAt": 1752219484056
+        }
+      },
+      "sNlLpOcAsLU_ZR8qaLfMz": {
+        "id": "sNlLpOcAsLU_ZR8qaLfMz",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "fork_count",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219495470,
+          "createAt": 1752219492791
+        }
+      },
+      "GLqibB1L4E7y7YKFUF_BI": {
+        "id": "GLqibB1L4E7y7YKFUF_BI",
+        "tableId": "WrKJrit6zGutAjdlQ5e8X",
+        "name": "score",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219499706,
+          "createAt": 1752219498024
+        }
+      },
+      "UlWidgU8sM_Vf6_2JJ-sU": {
+        "id": "UlWidgU8sM_Vf6_2JJ-sU",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "id",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219685547,
+          "createAt": 1752219545812
+        }
+      },
+      "SHtwCkTTl_Hi5shN8iVHC": {
+        "id": "SHtwCkTTl_Hi5shN8iVHC",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "year",
+        "comment": "github_id + year로 UQ1",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 128,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219733076,
+          "createAt": 1752219686897
+        }
+      },
+      "MxtTCSlbg5AXeXygX7yKZ": {
+        "id": "MxtTCSlbg5AXeXygX7yKZ",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "github_id",
+        "comment": "깃허브에서 제공하는 Id",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 127,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219695446,
+          "createAt": 1752219695446
+        }
+      },
+      "4uxsfjUz3RNN0Qmmp4UyC": {
+        "id": "4uxsfjUz3RNN0Qmmp4UyC",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "best_repo_name",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 88,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219748511,
+          "createAt": 1752219741833
+        }
+      },
+      "l7myLScWLmOOCQURO4M9G": {
+        "id": "l7myLScWLmOOCQURO4M9G",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "activity_level_score",
+        "comment": "활동 수준 점수",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 101,
+          "widthComment": 81,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219814747,
+          "createAt": 1752219753383
+        }
+      },
+      "Zupd_yM9fwxxJpus3SC2I": {
+        "id": "Zupd_yM9fwxxJpus3SC2I",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "activity_diversity_score",
+        "comment": "활동 다양성 점수",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 121,
+          "widthComment": 93,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219817765,
+          "createAt": 1752219785320
+        }
+      },
+      "h4sHCSW23Cx251ytQM8YK": {
+        "id": "h4sHCSW23Cx251ytQM8YK",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "activity_ influence_score",
+        "comment": "활동 영향력 점수",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 129,
+          "widthComment": 93,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219820511,
+          "createAt": 1752219793352
+        }
+      },
+      "Vt9RMvYJwx8pnRZQTXXDS": {
+        "id": "Vt9RMvYJwx8pnRZQTXXDS",
+        "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+        "name": "score",
+        "comment": "총 점수",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752219826751,
+          "createAt": 1752219821805
+        }
+      },
+      "hZARCVqk90iOTqno46DJo": {
+        "id": "hZARCVqk90iOTqno46DJo",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "unmerged_commit_count",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 137,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220596116,
+          "createAt": 1752220456276
+        }
+      },
+      "CWbbB4YfWctrUPrtu5UHD": {
+        "id": "CWbbB4YfWctrUPrtu5UHD",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "unmerged_commit_line",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 126,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220598517,
+          "createAt": 1752220545587
+        }
+      },
+      "u8ayETK9wl4viwzyFTNc5": {
+        "id": "u8ayETK9wl4viwzyFTNc5",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "unmerged_commit_add",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 127,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220603035,
+          "createAt": 1752220563634
+        }
+      },
+      "faPPSCOogg7Ca5wyneUpV": {
+        "id": "faPPSCOogg7Ca5wyneUpV",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "unmerged_commit_del",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 123,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1752220601140,
+          "createAt": 1752220572900
+        }
+      },
+      "3Iq0fSMTpUpBRSzTOG14_": {
+        "id": "3Iq0fSMTpUpBRSzTOG14_",
+        "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+        "name": "github_id",
+        "comment": "깃허브에서 제공하는 Id",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 127,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964419567,
+          "createAt": 1754964419567
+        }
+      },
+      "y4kue9YlcLC9VM7BOS4Ry": {
+        "id": "y4kue9YlcLC9VM7BOS4Ry",
+        "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+        "name": "repo_id",
+        "comment": "auto_increase",
+        "dataType": "",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 74,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964433672,
+          "createAt": 1754964423077
+        }
+      },
+      "ODv8w5x3x2vGpcQ69iwcy": {
+        "id": "ODv8w5x3x2vGpcQ69iwcy",
+        "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+        "name": "(github_id, repo_id)",
+        "comment": "복합 PK 키",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 104,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964747458,
+          "createAt": 1754964425598
+        }
+      },
+      "mf3o6sYMSWPL8aPIci0Ea": {
+        "id": "mf3o6sYMSWPL8aPIci0Ea",
+        "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964458545,
+          "createAt": 1754964455950
+        }
+      },
+      "caM1MHVviEIFb7HRrWply": {
+        "id": "caM1MHVviEIFb7HRrWply",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "repo_id",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 4,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964524293,
+          "createAt": 1754964465270
+        }
+      },
+      "iA57Gyx6CzHwbWiM4WpAP": {
+        "id": "iA57Gyx6CzHwbWiM4WpAP",
+        "tableId": "tGokp1AVC2q5Qtig6dDGu",
+        "name": "full_name",
+        "comment": "owner + repo로 자동 생성",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 141,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964503863,
+          "createAt": 1754964487694
+        }
+      },
+      "pxLMtSz99u9cp9EvA5Z0v": {
+        "id": "pxLMtSz99u9cp9EvA5Z0v",
+        "tableId": "oR066qCWPc9vOFCxpoHVl",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964733396,
+          "createAt": 1754964533622
+        }
+      },
+      "xbhjUV-f6eAGQluOf8ytD": {
+        "id": "xbhjUV-f6eAGQluOf8ytD",
+        "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+        "name": "id",
+        "comment": "auto",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964731826,
+          "createAt": 1754964566678
+        }
+      },
+      "snQEnCtCZuqyR0__Wefbh": {
+        "id": "snQEnCtCZuqyR0__Wefbh",
+        "tableId": "393ygiue4eRpi6k0hh9s-",
+        "name": "issue_id",
+        "comment": "깃허브에서 제공",
+        "dataType": "",
+        "default": "",
+        "options": 4,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 89,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754964654269,
+          "createAt": 1754964623406
+        }
+      }
+    },
+    "relationshipEntities": {
+      "TeYLqAdbWazR_Xc7ABHZi": {
+        "id": "TeYLqAdbWazR_Xc7ABHZi",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "1da5rkmF4UyMqKlWtJp43",
+          "columnIds": [
+            "rorIeLTinZV_ZnFEUfklH"
+          ],
+          "x": 264.5,
+          "y": 541,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "M98IyDSU7ob4spyji_LWS",
+          "columnIds": [
+            "HDc528cIZPglN0kMlWH5E"
+          ],
+          "x": 174.1945,
+          "y": 832.6666,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1752123128476,
+          "createAt": 1752123128476
+        }
+      },
+      "Vh8rxmZNboXlKCGZcN4UB": {
+        "id": "Vh8rxmZNboXlKCGZcN4UB",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "M98IyDSU7ob4spyji_LWS",
+          "columnIds": [
+            "uPC2xJQDjEXYLzF4Jgl9C"
+          ],
+          "x": 560.4445,
+          "y": 932.6666,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "f-aM0W8UR1yHFh10nodyV"
+          ],
+          "x": 1239.1388,
+          "y": 466.5927,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1752123384187,
+          "createAt": 1752123384187
+        }
+      },
+      "D93xB00L91sbgt4D7sq9M": {
+        "id": "D93xB00L91sbgt4D7sq9M",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1544.7297000000003,
+          "y": 549.7291,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "oR066qCWPc9vOFCxpoHVl",
+          "columnIds": [
+            "RsdNjvGgwKY29CdgZSnOu"
+          ],
+          "x": 1194.1676,
+          "y": 862.8226,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1752126938940,
+          "createAt": 1752126938940
+        }
+      },
+      "GmRjesxQENagJZvevu2gd": {
+        "id": "GmRjesxQENagJZvevu2gd",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1340.3297000000002,
+          "y": 549.7291,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "Wn5S9dcex38_Ns5BnGnWf",
+          "columnIds": [
+            "iwtkkvMPk9w-0sc6cB0YJ"
+          ],
+          "x": 1081.7060000000001,
+          "y": 1260.3322,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1752129072742,
+          "createAt": 1752129072742
+        }
+      },
+      "RJCYsX07OcBuMXYphZ3gZ": {
+        "id": "RJCYsX07OcBuMXYphZ3gZ",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1442.5297000000003,
+          "y": 549.7291,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "393ygiue4eRpi6k0hh9s-",
+          "columnIds": [
+            "9cdIz-_SgYQUEkt7b-r71"
+          ],
+          "x": 1088.2862,
+          "y": 1582.7949,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1752129232156,
+          "createAt": 1752129232156
+        }
+      },
+      "YBicdYW5cRtc31noK7_b8": {
+        "id": "YBicdYW5cRtc31noK7_b8",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1646.9297000000004,
+          "y": 549.7291,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "0zxLl9nDGiwLcUDfG_76z",
+          "columnIds": [
+            "R9d-yI0dFWdxk9KB4ut-G"
+          ],
+          "x": 1463.6054,
+          "y": 1310.8703,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1752129526693,
+          "createAt": 1752129526693
+        }
+      },
+      "Y6z6f3PMaEj3rJPnrmhwo": {
+        "id": "Y6z6f3PMaEj3rJPnrmhwo",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1749.1297000000004,
+          "y": 549.7291,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "tMWjzTM-_8N9H0y1dtpXu",
+          "columnIds": [
+            "_GXwWR21WdgBAcggabZJw"
+          ],
+          "x": 1611.2771,
+          "y": 1556.2694,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1752129636603,
+          "createAt": 1752129636603
+        }
+      },
+      "EvLclSg00jda9RnRNGxzY": {
+        "id": "EvLclSg00jda9RnRNGxzY",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "M98IyDSU7ob4spyji_LWS",
+          "columnIds": [
+            "uPC2xJQDjEXYLzF4Jgl9C"
+          ],
+          "x": 560.4445,
+          "y": 982.6666,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "WrKJrit6zGutAjdlQ5e8X",
+          "columnIds": [
+            "oUvQV6dHP7XQBq6KwwlwY"
+          ],
+          "x": 607.3478,
+          "y": 1184.4347,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1752219406164,
+          "createAt": 1752219406164
+        }
+      },
+      "_fEjO2v0-2LhqxsNfj0OU": {
+        "id": "_fEjO2v0-2LhqxsNfj0OU",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "M98IyDSU7ob4spyji_LWS",
+          "columnIds": [
+            "uPC2xJQDjEXYLzF4Jgl9C"
+          ],
+          "x": 302.9445,
+          "y": 1032.6666,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "oYgEYkx0-sM1-Bw27sM6B",
+          "columnIds": [
+            "MxtTCSlbg5AXeXygX7yKZ"
+          ],
+          "x": 262,
+          "y": 1513,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1752219695446,
+          "createAt": 1752219695446
+        }
+      },
+      "QQ33vOPy8SW0T1qr0FeDB": {
+        "id": "QQ33vOPy8SW0T1qr0FeDB",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "M98IyDSU7ob4spyji_LWS",
+          "columnIds": [
+            "uPC2xJQDjEXYLzF4Jgl9C"
+          ],
+          "x": 431.6945,
+          "y": 832.6666,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+          "columnIds": [
+            "3Iq0fSMTpUpBRSzTOG14_"
+          ],
+          "x": 635,
+          "y": 306,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1754964419567,
+          "createAt": 1754964419567
+        }
+      },
+      "EAc14BCyNZeNfqDgA1Qba": {
+        "id": "EAc14BCyNZeNfqDgA1Qba",
+        "identification": false,
+        "relationshipType": 4,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tGokp1AVC2q5Qtig6dDGu",
+          "columnIds": [
+            "SndfoACEixcnnO8PtUcQJ"
+          ],
+          "x": 1289.2297,
+          "y": 305.7291,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "SSx8AS1rDk2wnLrBbaKFz",
+          "columnIds": [
+            "y4kue9YlcLC9VM7BOS4Ry"
+          ],
+          "x": 1141,
+          "y": 306,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1754964423077,
+          "createAt": 1754964423077
+        }
+      }
+    },
+    "indexEntities": {},
+    "indexColumnEntities": {},
+    "memoEntities": {
+      "Rwy3Ef778V17qVSVlJYPq": {
+        "id": "Rwy3Ef778V17qVSVlJYPq",
+        "value": "깃허브 내부에서 관리하는 유저 정보는 다음 3가지\n{\n  \"login\": \"octocat\",\n  \"id\": 583231,\n  \"name\": \"The Octocat\",\n}\n\n이 중에서 id만 고유하고 나머지는 변경될 수 있기 때문에 무결성을 위해서 모든 테이블에서는 id를 FK로 참조하고 username이 필요하다면 Github_account 테이블과 join을 통해 가져올 것!",
+        "ui": {
+          "x": 401.4444,
+          "y": 597.3333,
+          "zIndex": 228,
+          "width": 349,
+          "height": 170,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1752219203986,
+          "createAt": 1752124517614
+        }
+      },
+      "J68we_lGTznnMLZDKoIvF": {
+        "id": "J68we_lGTznnMLZDKoIvF",
+        "value": "정규화를 위해서 여러명이 기여했지만 레포는 하나만 저장하고,\n조인 테이블을 이용해서 계정과 N:N관계 유지",
+        "ui": {
+          "x": 1008,
+          "y": 51,
+          "zIndex": 559,
+          "width": 255,
+          "height": 101,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1754964943243,
+          "createAt": 1754964843354
+        }
+      },
+      "XZ2R-MeDFlwNtyzlc2-iJ": {
+        "id": "XZ2R-MeDFlwNtyzlc2-iJ",
+        "value": "repo_id, sha 같은건 고유하긴 하지만, 번호가 랜덤이기 때문에 DB insert 비용이 높다.\nauto increment를 PK로 사용하고 repo_id, sha같은건 내부 unique key로 활용 ",
+        "ui": {
+          "x": 1240,
+          "y": 1026,
+          "zIndex": 596,
+          "width": 249,
+          "height": 100,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1754965050199,
+          "createAt": 1754964966520
+        }
+      }
+    }
+  }
+}

--- a/sosd-backend/docs/github_schema.erd.json
+++ b/sosd-backend/docs/github_schema.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 2000,
     "height": 2000,
-    "scrollTop": -680.2953,
+    "scrollTop": -475,
     "scrollLeft": -800,
-    "zoomLevel": 0.82,
+    "zoomLevel": 1,
     "show": 495,
     "database": 4,
     "databaseName": "",
@@ -1571,20 +1571,20 @@
       "PUkg1w0g_yUvchf_S09Uy": {
         "id": "PUkg1w0g_yUvchf_S09Uy",
         "tableId": "Wn5S9dcex38_Ns5BnGnWf",
-        "name": "pr_id",
+        "name": "github_pr_id",
         "comment": "깃허브에서 제공",
         "dataType": "",
         "default": "",
         "options": 12,
         "ui": {
           "keys": 0,
-          "widthName": 60,
+          "widthName": 68,
           "widthComment": 89,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1754964589094,
+          "updateAt": 1754978660864,
           "createAt": 1752129075619
         }
       },
@@ -2571,20 +2571,20 @@
       "caM1MHVviEIFb7HRrWply": {
         "id": "caM1MHVviEIFb7HRrWply",
         "tableId": "tGokp1AVC2q5Qtig6dDGu",
-        "name": "repo_id",
+        "name": "github_repo_id",
         "comment": "",
         "dataType": "",
         "default": "",
         "options": 4,
         "ui": {
           "keys": 0,
-          "widthName": 60,
+          "widthName": 81,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1754964524293,
+          "updateAt": 1754978641441,
           "createAt": 1754964465270
         }
       },
@@ -2651,20 +2651,20 @@
       "snQEnCtCZuqyR0__Wefbh": {
         "id": "snQEnCtCZuqyR0__Wefbh",
         "tableId": "393ygiue4eRpi6k0hh9s-",
-        "name": "issue_id",
+        "name": "github_issue_id",
         "comment": "깃허브에서 제공",
         "dataType": "",
         "default": "",
         "options": 4,
         "ui": {
           "keys": 0,
-          "widthName": 60,
+          "widthName": 83,
           "widthComment": 89,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1754964654269,
+          "updateAt": 1754978668669,
           "createAt": 1754964623406
         }
       }
@@ -2736,7 +2736,7 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1544.7297000000003,
+          "x": 1545.2297000000003,
           "y": 549.7291,
           "direction": 8
         },
@@ -2764,7 +2764,7 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1340.3297000000002,
+          "x": 1340.4297000000001,
           "y": 549.7291,
           "direction": 8
         },
@@ -2792,7 +2792,7 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1442.5297000000003,
+          "x": 1442.8297000000002,
           "y": 549.7291,
           "direction": 8
         },
@@ -2801,7 +2801,7 @@
           "columnIds": [
             "9cdIz-_SgYQUEkt7b-r71"
           ],
-          "x": 1088.2862,
+          "x": 1096.2862,
           "y": 1582.7949,
           "direction": 2
         },
@@ -2820,7 +2820,7 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1646.9297000000004,
+          "x": 1647.6297000000004,
           "y": 549.7291,
           "direction": 8
         },
@@ -2848,7 +2848,7 @@
           "columnIds": [
             "SndfoACEixcnnO8PtUcQJ"
           ],
-          "x": 1749.1297000000004,
+          "x": 1750.0297000000005,
           "y": 549.7291,
           "direction": 8
         },

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/GithubRepositoryUpsertDto.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/GithubRepositoryUpsertDto.java
@@ -1,0 +1,61 @@
+package com.sosd.sosd_backend.dto;
+
+
+import com.sosd.sosd_backend.github_collector.dto.GithubRepositoryResponseDto;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public record GithubRepositoryUpsertDto(
+        Long githubRepoId,
+        String ownerName,
+        String repoName,
+        String defaultBranch,
+        Integer watcher,
+        Integer star,
+        Integer fork,
+        Integer dependency,
+        String description,
+        String readme,
+        String license,
+        LocalDateTime githubRepositoryCreatedAt,
+        LocalDateTime githubRepositoryUpdatedAt,
+        LocalDateTime githubPushedAt,
+        String additionalData,
+        Integer contributor,
+        Boolean isPrivate
+) {
+    /** GithubRepositoryResponseDto → UpsertDto 변환 */
+    public static GithubRepositoryUpsertDto from(GithubRepositoryResponseDto dto) {
+        return new GithubRepositoryUpsertDto(
+                dto.id(),
+                dto.ownerNameOnly(),
+                dto.repoNameOnly(),
+                nvl(dto.defaultBranch(), "main"),
+                dto.watchers(),
+                dto.stargazersCount(),
+                dto.forks(),
+                null, // dependency → hydrate 단계에서
+                dto.description(),
+                null, // readme → hydrate 단계에서
+                dto.license() != null ? dto.license().name() : null,
+                toUtcLocal(dto.createdAt()),
+                toUtcLocal(dto.updatedAt()),
+                toUtcLocal(dto.pushedAt()),
+                null, // additionalData → hydrate 단계에서
+                null, // contributor → hydrate 단계에서
+                dto.isPrivate()
+        );
+    }
+
+    // ---- private helpers ----
+    private static String nvl(String v, String def) {
+        return (v == null || v.isBlank()) ? def : v;
+    }
+
+    private static LocalDateTime toUtcLocal(OffsetDateTime odt) {
+        return odt != null ? odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+    }
+
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubAccount.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,6 +42,16 @@ public class GithubAccount {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private UserAccount userAccount;
+
+    // 레포지토리 다대다 설정
+    // account -> repo 로 단방향 many to many 설정
+    @ManyToMany
+    @JoinTable(
+            name = "github_account_repository",
+            joinColumns = @JoinColumn(name = "github_account_id", referencedColumnName = "github_id"),
+            inverseJoinColumns = @JoinColumn(name = "github_repo_id", referencedColumnName = "id")
+    )
+    private Set<GithubRepositoryEntity> repositoryEntities = new HashSet<>();
 
     // 생성자
     @Builder

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubRepositoryEntity.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubRepositoryEntity.java
@@ -12,11 +12,15 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "repository")
+@Table(name = "github_repository")
 public class GithubRepositoryEntity {
     @Id
-    @Column(name = "repo_id", nullable = false)
-    private Long repoId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "github_repo_id", nullable = false)
+    private Long githubRepoId;
 
     @Column(name = "owner_name", nullable = false)
     private String ownerName;
@@ -24,11 +28,11 @@ public class GithubRepositoryEntity {
     @Column(name = "repo_name", nullable = false)
     private String repoName;
 
+    @Column(name = "full_name", insertable = false, updatable = false)
+    private String fullName;
+
     @Column(name = "default_branch", nullable = false)
     private String defaultBranch;
-
-    @Column(name = "score")
-    private Integer score;
 
     @Column(name = "watcher")
     private Integer watcher;
@@ -38,36 +42,6 @@ public class GithubRepositoryEntity {
 
     @Column(name = "fork")
     private Integer fork;
-
-    @Column(name = "commit_count")
-    private Integer commitCount;
-
-    @Column(name = "commit_line")
-    private Integer commitLine;
-
-    @Column(name = "commit_del")
-    private Integer commitDel;
-
-    @Column(name = "commit_add")
-    private Integer commitAdd;
-
-    @Column(name = "unmerged_commit_count")
-    private Integer unmergedCommitCount;
-
-    @Column(name = "unmerged_commit_line")
-    private Integer unmergedCommitLine;
-
-    @Column(name = "unmerged_commit_del")
-    private Integer unmergedCommitDel;
-
-    @Column(name = "unmerged_commit_add")
-    private Integer unmergedCommitAdd;
-
-    @Column(name = "pr")
-    private Integer pr;
-
-    @Column(name = "issue")
-    private Integer issue;
 
     @Column(name = "dependency")
     private Integer dependency;
@@ -87,8 +61,8 @@ public class GithubRepositoryEntity {
     @Column(name = "github_repository_updated_at", nullable = false)
     private LocalDateTime githubRepositoryUpdatedAt;
 
-    @Column(name = "pushed_at", nullable = false)
-    private LocalDateTime pushedAt;
+    @Column(name = "github_pushed_at", nullable = false)
+    private LocalDateTime githubPushedAt;
 
     @Column(name = "additional_data", columnDefinition = "TEXT")
     private String additionalData;
@@ -99,29 +73,23 @@ public class GithubRepositoryEntity {
     @Column(name = "is_private")
     private Boolean isPrivate;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "github_id", nullable = false)
-    private GithubAccount githubAccount;
-
     @Builder
     public GithubRepositoryEntity(
-            Long repoId,
+            Long githubRepoId,
             String ownerName,
             String repoName,
             String defaultBranch,
             LocalDateTime githubRepositoryCreatedAt,
             LocalDateTime githubRepositoryUpdatedAt,
-            LocalDateTime pushedAt,
-            GithubAccount githubAccount
+            LocalDateTime githubPushedAt
     ) {
-        this.repoId = repoId;
+        this.githubRepoId = githubRepoId;
         this.ownerName = ownerName;
         this.repoName = repoName;
         this.defaultBranch = defaultBranch;
         this.githubRepositoryCreatedAt = githubRepositoryCreatedAt;
         this.githubRepositoryUpdatedAt = githubRepositoryUpdatedAt;
-        this.pushedAt = pushedAt;
-        this.githubAccount = githubAccount;
+        this.githubPushedAt = githubPushedAt;
     }
 
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubRepositoryEntity.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/entity/github/GithubRepositoryEntity.java
@@ -1,6 +1,7 @@
 package com.sosd.sosd_backend.entity.github;
 
 
+import com.sosd.sosd_backend.dto.GithubRepositoryUpsertDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -90,6 +91,50 @@ public class GithubRepositoryEntity {
         this.githubRepositoryCreatedAt = githubRepositoryCreatedAt;
         this.githubRepositoryUpdatedAt = githubRepositoryUpdatedAt;
         this.githubPushedAt = githubPushedAt;
+    }
+
+
+    public static GithubRepositoryEntity from(GithubRepositoryUpsertDto dto) {
+        // null 체크
+        if (dto.githubRepoId() == null) throw new IllegalArgumentException("Github repository id cannot be null");
+        if (dto.ownerName() == null) throw new IllegalArgumentException("Owner name cannot be null");
+        if (dto.repoName() == null) throw new IllegalArgumentException("Repo name cannot be null");
+        if (dto.defaultBranch() == null) throw new IllegalArgumentException("Default branch cannot be null");
+        if (dto.githubRepositoryUpdatedAt() == null) throw new IllegalArgumentException("Github repository updated at cannot be null");
+        if (dto.githubRepositoryCreatedAt() == null) throw new IllegalArgumentException("Github repository created a cannot be null");
+        if (dto.githubPushedAt() == null) throw new IllegalArgumentException("Github repository pushed at cannot be null");
+
+        GithubRepositoryEntity e = GithubRepositoryEntity.builder()
+                .githubRepoId(dto.githubRepoId())
+                .ownerName(dto.ownerName())
+                .repoName(dto.repoName())
+                .defaultBranch(dto.defaultBranch())
+                .githubRepositoryCreatedAt(dto.githubRepositoryCreatedAt())
+                .githubRepositoryUpdatedAt(dto.githubRepositoryUpdatedAt())
+                .githubPushedAt(dto.githubPushedAt())
+                .build();
+        e.merge(dto);
+        return e;
+    }
+
+    /** 부분 업데이트: null/blank가 아닌 값만 반영. 식별자(githubRepoId)는 변경하지 않음. */
+    public void merge(GithubRepositoryUpsertDto dto){
+        if (dto.ownerName() != null) this.ownerName = dto.ownerName();
+        if (dto.repoName() != null) this.repoName = dto.repoName();
+        if (dto.defaultBranch() != null && !dto.defaultBranch().isBlank()) this.defaultBranch = dto.defaultBranch();
+        if (dto.watcher() != null) this.watcher = dto.watcher();
+        if (dto.star() != null) this.star = dto.star();
+        if (dto.fork() != null) this.fork = dto.fork();
+        if (dto.dependency() != null) this.dependency = dto.dependency();
+        if (dto.description() != null) this.description = dto.description();
+        if (dto.readme() != null) this.readme = dto.readme();
+        if (dto.license() != null) this.license = dto.license();
+        if (dto.githubRepositoryCreatedAt() != null) this.githubRepositoryCreatedAt = dto.githubRepositoryCreatedAt();
+        if (dto.githubRepositoryUpdatedAt() != null) this.githubRepositoryUpdatedAt = dto.githubRepositoryUpdatedAt();
+        if (dto.githubPushedAt() != null) this.githubPushedAt = dto.githubPushedAt();
+        if (dto.additionalData() != null) this.additionalData = dto.additionalData();
+        if (dto.contributor() != null) this.contributor = dto.contributor();
+        if (dto.isPrivate() != null) this.isPrivate = dto.isPrivate();
     }
 
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/collector/RepoCollector.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/collector/RepoCollector.java
@@ -1,6 +1,6 @@
 package com.sosd.sosd_backend.github_collector.collector;
 
-import com.sosd.sosd_backend.dto.RepositoryDetailDto;
+import com.sosd.sosd_backend.github_collector.dto.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.github_collector.dto.RepoCollectorDtos.EventRepoDto;
 import com.sosd.sosd_backend.github_collector.dto.RepoCollectorDtos.SearchIssuesDto;
 import com.sosd.sosd_backend.github_collector.dto.RepoCollectorDtos.UserRepoDto;
@@ -22,7 +22,7 @@ public class RepoCollector {
     /**
      * username이 기여한 모든 repo의 상세 정보를 반환
      */
-    public List<RepositoryDetailDto> getAllContributedRepos(String username) {
+    public List<GithubRepositoryResponseDto> getAllContributedRepos(String username) {
         Set<String> fullNames = new HashSet<>();
 
         fullNames.addAll(fetchReposFromUserRepos(username));
@@ -48,14 +48,15 @@ public class RepoCollector {
     /**
      * 단일 repo 정보 조회
      */
-    public RepositoryDetailDto getRepoInfo(String owner, String name){
+    public GithubRepositoryResponseDto getRepoInfo(String owner, String name){
         try {
             return githubRestClient.request()
                     .endpoint("/repos/" + owner + "/" + name)
-                    .get(RepositoryDetailDto.class);
+                    .get(GithubRepositoryResponseDto.class);
         } catch (org.springframework.web.client.HttpClientErrorException.NotFound e) {
             // 404 에러 발생 시 null 반환
-            return null;        }
+            return null;
+        }
     }
 
 

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/GithubRepositoryResponseDto.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/GithubRepositoryResponseDto.java
@@ -1,10 +1,10 @@
-package com.sosd.sosd_backend.dto;
+package com.sosd.sosd_backend.github_collector.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 
-public record RepositoryDetailDto(
+public record GithubRepositoryResponseDto(
         long id,
         @JsonProperty("full_name") String fullName,
         @JsonProperty("private") boolean isPrivate, //

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
@@ -14,22 +14,21 @@ import java.util.Optional;
 public interface GithubRepositoryRepository extends JpaRepository<GithubRepositoryEntity, Long> {
 
     // PK로 단건 조회
-    boolean existsByRepoId(Long repoId);
-    Optional<GithubRepositoryEntity> findByRepoId(Long repoId);
+    boolean existsByGithubRepoId(Long githubRepoId);
+    Optional<GithubRepositoryEntity> findByGithubRepoId(Long githubRepoId);
+
+    // githubRepoId 기준으로 벌크 로딩
+    List<GithubRepositoryEntity> findALLByGithubRepoIdIn(Collection<Long> githubRepoIds);
 
     // 유니크 인덱스
     boolean existsByOwnerNameAndRepoName(String ownerName, String repoName);
     Optional<GithubRepositoryEntity> findByOwnerNameAndRepoName(String ownerName, String repoName);
+    Optional<GithubRepositoryEntity> findByFullName(String fullName);
 
-    // GithubAccount로 일괄 조회
-    List<GithubRepositoryEntity> findAllByGithubAccount(GithubAccount githubAccount);
+    // PK 다건 조회
+    List<GithubRepositoryEntity> findAllByIdIn(Collection<Long> ids);
 
-    // GithubAccount의 PK(=github_id)로 조회
-    List<GithubRepositoryEntity> findAllByGithubAccount_GithubId(Integer githubId);
-
-    List<GithubRepositoryEntity> findAllByGithubAccount_GithubLoginUsername(String githubLoginUsername);
-
-    // 여러 repoId로 한 번에 조회
-    List<GithubRepositoryEntity> findAllByRepoIdIn(Collection<Integer> repoIds);
+    // 변경 시각 기준 조회
+    List<GithubRepositoryEntity> findAllByGithubRepositoryUpdatedAtAfter(LocalDateTime since);
 
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/repository/github/GithubRepositoryRepository.java
@@ -18,7 +18,7 @@ public interface GithubRepositoryRepository extends JpaRepository<GithubReposito
     Optional<GithubRepositoryEntity> findByGithubRepoId(Long githubRepoId);
 
     // githubRepoId 기준으로 벌크 로딩
-    List<GithubRepositoryEntity> findALLByGithubRepoIdIn(Collection<Long> githubRepoIds);
+    List<GithubRepositoryEntity> findAllByGithubRepoIdIn(Collection<Long> githubRepoIds);
 
     // 유니크 인덱스
     boolean existsByOwnerNameAndRepoName(String ownerName, String repoName);

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoIngestionService.java
@@ -1,6 +1,7 @@
 package com.sosd.sosd_backend.service.github;
 
-import com.sosd.sosd_backend.dto.RepositoryDetailDto;
+import com.sosd.sosd_backend.dto.GithubRepositoryUpsertDto;
+import com.sosd.sosd_backend.github_collector.dto.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,10 +30,15 @@ public class RepoIngestionService {
 
     public void ingestGithubAccount(String githubLoginUsername){
         // 1) 깃허브 api를 통해 수집
-        List<RepositoryDetailDto> dtos = repoCollector.getAllContributedRepos(githubLoginUsername);
+        List<GithubRepositoryResponseDto> collectedDto = repoCollector.getAllContributedRepos(githubLoginUsername);
 
-        // 2) 저장
-        repoUpsertService.upsertRepos(githubLoginUsername, dtos);
+        // 2) GithubRepositoryUpsertDto로 변환
+        List<GithubRepositoryUpsertDto> upsertDtos = collectedDto.stream()
+                .map(GithubRepositoryUpsertDto::from)
+                        .toList();
+
+        // 3) 저장
+        repoUpsertService.upsertRepos(upsertDtos);
 
     }
 

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
@@ -1,7 +1,7 @@
 package com.sosd.sosd_backend.service.github;
 
-import com.sosd.sosd_backend.dto.RepositoryDetailDto;
-import com.sosd.sosd_backend.entity.github.GithubAccount;
+import com.sosd.sosd_backend.dto.GithubRepositoryUpsertDto;
+
 import com.sosd.sosd_backend.entity.github.GithubRepositoryEntity;
 import com.sosd.sosd_backend.repository.github.GithubAccountRepository;
 import com.sosd.sosd_backend.repository.github.GithubRepositoryRepository;
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -21,53 +18,41 @@ public class RepoUpsertService {
     private final GithubRepositoryRepository githubRepositoryRepository;
     private final GithubAccountRepository githubAccountRepository;
 
-    /**
-     * 주어진 GitHub 계정이 기여한 저장소 목록을 DB에 Upsert(Insert or Update) 처리합니다.
-     * <ul>
-     *   <li>PK(repoId) 기준 신규 저장소는 INSERT, 기존 저장소는 UPDATE 수행</li>
-     *   <li>호출 전 외부 API 수집은 완료되어 있어야 함</li>
-     *   <li>트랜잭션 전체를 커버하여 원자성 보장</li>
-     * </ul>
-     *
-     * @param githubLoginUsername GitHub 계정 로그인 ID
-     * @param dtos 수집된 저장소 상세 정보 리스트
-     * @throws RuntimeException 해당 계정이 DB에 존재하지 않을 경우
-     */
     @Transactional
-    public void upsertRepos(String githubLoginUsername, List<RepositoryDetailDto> dtos){
-        // 2-1) 계정 로딩
-        GithubAccount githubAccount = githubAccountRepository.findByGithubLoginUsername(githubLoginUsername)
-                .orElseThrow(() -> new RuntimeException("Github Account 없음: " + githubLoginUsername));
+    public void upsertRepos(List<GithubRepositoryUpsertDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return;
+        }
 
-        // 2-2) 레포지토리 엔티티로 변환
-        List<GithubRepositoryEntity> entities = dtos.stream()
-                .map(dto -> toEntity(dto, githubAccount))
+        // 1) 입력 검증 + 키 수집
+        List<Long> ids = dtos.stream()
+                .map(GithubRepositoryUpsertDto::githubRepoId)
+                .filter(Objects::nonNull)
                 .toList();
+        if (ids.isEmpty()) return;
 
-        // 2-3) 저장 (한 계정이 보유한 repository는 보통 그렇게 많지 않기 때문에 네이티브 사용x)
-        githubRepositoryRepository.saveAll(entities);
+        // 2) 기존 엔티티 벌크 로딩
+        List<GithubRepositoryEntity> existing = githubRepositoryRepository.findALLByGithubRepoIdIn(ids);
+        Map<Long, GithubRepositoryEntity> byRepoId = new HashMap<>(existing.size());
+        for (GithubRepositoryEntity entity : existing) {
+            byRepoId.put(entity.getGithubRepoId(), entity);
+        }
 
+        // 3) 머지/신규 생성
+        List<GithubRepositoryEntity> toSave = new ArrayList<>(dtos.size());
+        for (GithubRepositoryUpsertDto dto : dtos) {
+            GithubRepositoryEntity entity = byRepoId.get(dto.githubRepoId());
+            if (entity == null) {
+                // 신규
+                entity = GithubRepositoryEntity.from(dto);
+            } else {
+                // 업데이트
+                entity.merge(dto);
+            }
+            toSave.add(entity);
+        }
+        githubRepositoryRepository.saveAll(toSave);
     }
 
-    private GithubRepositoryEntity toEntity(RepositoryDetailDto dto, GithubAccount account){
-        return GithubRepositoryEntity.builder()
-                .repoId(dto.id())
-                .ownerName(dto.ownerNameOnly())
-                .repoName(dto.repoNameOnly())
-                .defaultBranch(nvl(dto.defaultBranch(), "main"))
-                .githubRepositoryCreatedAt(toUtcLocal(dto.createdAt()))
-                .githubRepositoryUpdatedAt(toUtcLocal(dto.updatedAt()))
-                .pushedAt(toUtcLocal(dto.pushedAt()))
-                .githubAccount(account)
-                .build();
-    }
-
-    private static LocalDateTime toUtcLocal(OffsetDateTime odt) {
-        return odt != null ? odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
-    }
-
-    private static String nvl(String v, String def) {
-        return (v == null || v.isEmpty()) ? def : v;
-    }
 
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/service/github/RepoUpsertService.java
@@ -32,7 +32,7 @@ public class RepoUpsertService {
         if (ids.isEmpty()) return;
 
         // 2) 기존 엔티티 벌크 로딩
-        List<GithubRepositoryEntity> existing = githubRepositoryRepository.findALLByGithubRepoIdIn(ids);
+        List<GithubRepositoryEntity> existing = githubRepositoryRepository.findAllByGithubRepoIdIn(ids);
         Map<Long, GithubRepositoryEntity> byRepoId = new HashMap<>(existing.size());
         for (GithubRepositoryEntity entity : existing) {
             byRepoId.put(entity.getGithubRepoId(), entity);

--- a/sosd-backend/src/main/resources/schema/github-schema.sql
+++ b/sosd-backend/src/main/resources/schema/github-schema.sql
@@ -52,7 +52,6 @@ CREATE TABLE IF NOT EXISTS github_repository (
 CREATE TABLE IF NOT EXISTS github_account_repository (
     github_account_id BIGINT NOT NULL COMMENT 'github_account 테이블 id (외례키)',
     github_repo_id BIGINT NOT NULL COMMENT 'github_repository 테이블 id (외례키)',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (github_account_id, github_repo_id) COMMENT '복합 PK',
 
     -- 인덱스

--- a/sosd-backend/src/main/resources/schema/github-schema.sql
+++ b/sosd-backend/src/main/resources/schema/github-schema.sql
@@ -12,54 +12,58 @@ CREATE TABLE IF NOT EXISTS github_account (
 
     -- 인덱스
     INDEX idx_github_account_login (github_login_username) COMMENT 'username을 통한 조회용',
-    INDEX idx_github_account_last_crawling (last_crawling) COMMENT '스케쥴링할 때 기간 쿼리용'
+    INDEX idx_github_account_last_crawling (last_crawling) COMMENT '스케쥴링할 때 기간 쿼리용',
+    INDEX idx_github_account_student_id (student_id) COMMENT '학번을 통한 조회'
 
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub 계정 테이블';
 
 -- Repository 테이블
-CREATE TABLE IF NOT EXISTS repository (
-    repo_id BIGINT NOT NULL PRIMARY KEY COMMENT '깃허브에서 제공하는 고유 id',
+CREATE TABLE IF NOT EXISTS github_repository (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+    github_repo_id BIGINT NOT NULL COMMENT '깃허브에서 제공하는 고유 id',
     owner_name VARCHAR(255) NOT NULL COMMENT '저장소 소유자명',
     repo_name VARCHAR(255) NOT NULL COMMENT '저장소명',
+    full_name VARCHAR(512) AS (CONCAT(owner_name, '/' ,repo_name)) STORED COMMENT 'full name 자동 생성',
     default_branch VARCHAR(255) NOT NULL COMMENT '기본 브랜치명',
-    score INT DEFAULT 0 COMMENT '깃허브 점수',
     watcher INT DEFAULT 0 COMMENT '구독자 수',
     star INT DEFAULT 0 COMMENT '스타 수',
     fork INT DEFAULT 0 COMMENT '포크 수',
-    commit_count INT DEFAULT 0 COMMENT '총 커밋 수',
-    commit_line INT DEFAULT 0 COMMENT '총 커밋 라인 수',
-    commit_del INT DEFAULT 0 COMMENT '총 삭제 라인 수',
-    commit_add INT DEFAULT 0 COMMENT '총 추가 라인 수',
-    unmerged_commit_count INT DEFAULT 0 COMMENT '미병합 커밋 수',
-    unmerged_commit_line INT DEFAULT 0 COMMENT '미병합 커밋 라인 수',
-    unmerged_commit_del INT DEFAULT 0 COMMENT '미병합 삭제 라인 수',
-    unmerged_commit_add INT DEFAULT 0 COMMENT '미병합 추가 라인 수',
-    pr INT DEFAULT 0 COMMENT 'Pull Request 수',
-    issue INT DEFAULT 0 COMMENT 'Issue 수',
     dependency INT DEFAULT 0 COMMENT '의존성 수',
     description VARCHAR(255) COMMENT '저장소 설명',
     readme TEXT COMMENT 'README 내용',
     license VARCHAR(255) COMMENT '라이선스 이름',
     github_repository_created_at DATETIME NOT NULL COMMENT '생성 일시',
     github_repository_updated_at DATETIME NOT NULL COMMENT '수정 일시',
-    pushed_at DATETIME NOT NULL COMMENT '마지막 푸시일시',
+    github_pushed_at DATETIME NOT NULL COMMENT '마지막 푸시일시',
     additional_data TEXT COMMENT '사용 언어 등 추가 정보 (JSON 형태)', -- 별도 테이블로 정규화할지 논의
     contributor INT DEFAULT 0 COMMENT '기여자 수',
     is_private BOOLEAN DEFAULT FALSE COMMENT '비공개 여부',
-    github_id BIGINT NOT NULL COMMENT 'GitHub 계정 ID (외래키)',
 
     -- 인덱스
-    INDEX idx_repository_github_id (github_id, is_private) COMMENT '특정 사용자의 저장소 조회용',
-    INDEX idx_repository_owner_repo (owner_name, repo_name, is_private) COMMENT '저장소 full_name으로 직접 조회용 (owner/repo)',
+    UNIQUE INDEX uq_repository_github_repo_id (github_repo_id) COMMENT '깃허브 저장소 고유 ID (깃허브 api에서 제공)',
+    INDEX idx_repository_owner_repo (owner_name, repo_name, is_private) COMMENT '저장소 owner + name 조합으로 직접 조회용 (owner/repo)',
+    INDEX idx_repository_full_name (full_name, is_private) COMMENT '저장소 full_name으로 직접 조회',
     INDEX idx_repository_created_at (github_repository_created_at,is_private) COMMENT '생성일 기준 조회 및 통계용',
-    INDEX idx_repository_updated_at (github_repository_updated_at,is_private) COMMENT '최근 업데이트 저장소 조회용',
-    INDEX idx_repository_score (score, is_private) COMMENT '점수 기준 랭킹 및 정렬용'
+    INDEX idx_repository_updated_at (github_repository_updated_at,is_private) COMMENT '최근 업데이트 저장소 조회용'
 
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub 레포지토리 테이블';
 
+-- github_account와 github_repository의 다대다 관계를 위한 조인 테이블
+CREATE TABLE IF NOT EXISTS github_account_repository (
+    github_account_id BIGINT NOT NULL COMMENT 'github_account 테이블 id (외례키)',
+    github_repo_id BIGINT NOT NULL COMMENT 'github_repository 테이블 id (외례키)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (github_account_id, github_repo_id) COMMENT '복합 PK',
+
+    -- 인덱스
+    INDEX idx_account_repository_repo_id (github_repo_id, github_account_id) COMMENT '저장소 id를 통한 계정 조회용'
+
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='github_account - github_repository 조인 테이블 ';
+
 -- Commit 테이블
-CREATE TABLE IF NOT EXISTS `commit` (
-    sha VARCHAR(40) NOT NULL PRIMARY KEY COMMENT 'Git commit SHA (40자 고정길이 해시값)',
+CREATE TABLE IF NOT EXISTS github_commit (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    sha VARCHAR(40) NOT NULL COMMENT 'Git commit SHA (40자 고정길이 해시값)',
     addition INT NOT NULL COMMENT '추가된 라인 수',
     deletion INT NOT NULL COMMENT '삭제된 라인 수',
     author_date DATETIME NOT NULL COMMENT '커밋 작성자 시간',
@@ -69,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `commit` (
     repo_id BIGINT NOT NULL COMMENT '저장소 ID (외래키)',
 
     -- 인덱스
-
+    UNIQUE INDEX uq_commit_sha (sha) COMMENT 'commit 고유 sha 값 유니크 키',
     INDEX idx_commit_branch (branch) COMMENT 'default 브랜치 병합 조회용',
     INDEX idx_commit_repo_id (repo_id) COMMENT '레포지토리 기준 커밋 조회용'
 
@@ -77,8 +81,9 @@ CREATE TABLE IF NOT EXISTS `commit` (
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Github 커밋 테이블';
 
 -- Pull Request 테이블
-CREATE TABLE IF NOT EXISTS pull_request (
-    pr_id BIGINT NOT NULL PRIMARY KEY COMMENT 'GitHub Pull Request ID (깃허브에서 제공하는 고유 id)',
+CREATE TABLE IF NOT EXISTS github_pull_request (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    github_pr_id BIGINT NOT NULL COMMENT 'GitHub Pull Request ID (깃허브에서 제공하는 고유 id)',
     pr_number INT NOT NULL COMMENT 'Pull Request 번호',
     pr_title VARCHAR(255) NOT NULL COMMENT 'Pull Request 제목',
     pr_body TEXT COMMENT 'Pull Request 본문',
@@ -89,6 +94,7 @@ CREATE TABLE IF NOT EXISTS pull_request (
     repo_id BIGINT NOT NULL COMMENT '저장소 ID (외래키)',
 
     -- 인덱스
+    UNIQUE uq_pull_request_github_pr_id (github_pr_id) COMMENT 'pr id 유니크 키 (깃허브 api에서 제공)',
     INDEX idx_repo_id_pr_number (repo_id, pr_number) COMMENT 'pr 조회용',
     INDEX idx_merged (merged) COMMENT '병합 여부 조회용',
     INDEX idx_pr_date (pr_date) COMMENT 'pr 생성 날짜 필터용'
@@ -96,8 +102,9 @@ CREATE TABLE IF NOT EXISTS pull_request (
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub Pull Request 테이블';
 
 -- Issue 테이블
-CREATE TABLE IF NOT EXISTS issue (
-    issue_id BIGINT NOT NULL PRIMARY KEY COMMENT 'GitHub Issue ID (깃허브에서 제공하는 고유 id)',
+CREATE TABLE IF NOT EXISTS github_issue (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    github_issue_id BIGINT NOT NULL COMMENT 'GitHub Issue ID (깃허브에서 제공하는 고유 id)',
     issue_number INT NOT NULL COMMENT 'Issue 번호',
     issue_title VARCHAR(255) NOT NULL COMMENT 'Issue 제목',
     issue_body TEXT COMMENT 'Issue 본문',
@@ -105,13 +112,14 @@ CREATE TABLE IF NOT EXISTS issue (
     repo_id BIGINT NOT NULL COMMENT '저장소 ID (외래키)',
 
     -- 인덱스
+    UNIQUE uq_issue_github_issue_id (github_issue_id) COMMENT 'issue id 유니크 키 (깃허브 api에서 제공)',
     INDEX idx_repo_id_issue_number (repo_id, issue_number) COMMENT 'issue 조회용',
     INDEX idx_issue_date (issue_date) COMMENT 'issue 생성 날짜 조회용'
 
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub Issue 테이블';
 
 -- Fork 테이블
-CREATE TABLE IF NOT EXISTS fork (
+CREATE TABLE IF NOT EXISTS github_fork (
     id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Auto increment ID',
     fork_user_id BIGINT NOT NULL COMMENT 'Fork한 사용자 ID',
     fork_date DATETIME NOT NULL COMMENT 'Fork 일시',
@@ -124,7 +132,7 @@ CREATE TABLE IF NOT EXISTS fork (
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='GitHub Fork 테이블';
 
 -- Star 테이블
-CREATE TABLE IF NOT EXISTS star (
+CREATE TABLE IF NOT EXISTS github_star (
     id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Auto increment ID',
     star_user_id BIGINT NOT NULL COMMENT 'Star한 사용자 ID',
     star_date DATETIME NOT NULL COMMENT 'Star 일시',

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
@@ -1,6 +1,6 @@
 package com.sosd.sosd_backend.github_collector;
 
-import com.sosd.sosd_backend.dto.RepositoryDetailDto;
+import com.sosd.sosd_backend.github_collector.dto.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +18,7 @@ public class RepoCollectTest {
 
     @Test
     void testGetRepoInfo(){
-        RepositoryDetailDto testRepoDto = repoCollector.getRepoInfo("SKKU-OSP", "SKKU-OSP");
+        GithubRepositoryResponseDto testRepoDto = repoCollector.getRepoInfo("SKKU-OSP", "SKKU-OSP");
 
         assertEquals(503242724L, testRepoDto.id(), "Repo ID가 일치하지 않습니다");
         assertEquals(107451259L, testRepoDto.owner().id(), "Owner ID가 일치하지 않습니다");
@@ -29,8 +29,8 @@ public class RepoCollectTest {
 
     @Test
     void testGetAllReposFromUser(){
-        List<RepositoryDetailDto> repoLists = repoCollector.getAllContributedRepos("ki011127");
-        for(RepositoryDetailDto repo : repoLists){
+        List<GithubRepositoryResponseDto> repoLists = repoCollector.getAllContributedRepos("ki011127");
+        for(GithubRepositoryResponseDto repo : repoLists){
             System.out.println(repo.fullName());
         }
     }


### PR DESCRIPTION
## 📌 PR 개요

GitHub 계정과 레포지토리 간의 다대다 관계를 지원하기 위한 DB 구조 개선 및 서비스 레이어 분리

## 🛠 작업 내용

- [x] DB 스키마 변경
- 계정(Account)과 레포지토리(Repository) 간 다대다 관계 설정
    - 기존: github_account + repo_id를 묶어 유니크 키로 설정 (1:N 관계)
    - 문제점: 레포 테이블에 중복 데이터 발생, 정규화 위반
    - 개선: 조인 테이블을 통한 M:N 관계로 변경
- PK 전략 변경 (auto increment 도입)
    - 기존: repo_id, sha 등 GitHub 제공 값을 PK로 사용
    - 문제점: 랜덤 값으로 인한 INSERT 성능 저하
    - 개선: auto increment PK + GitHub 값은 UK로 설정

<details>
<summary>변경된 DB구조 ERD</summary>
<div markdown="1">
<img width="2000" height="2000" alt="unnamed-2025-08-14T14_44_30" src="https://github.com/user-attachments/assets/753ea15a-66b3-412f-854e-c42f41c213ca" />

</div>
</details>

- [x] 레이어 분리 및 책임 명확화
- `RepoIngestionService`: 외부 API 레포 수집 및 전체 프로세스 조율
- `RepoUpsertService`: DB upsert 로직 전담
- `GithubRepositoryUpsertDto`: 내부 도메인용 DTO 추가
- `GithubRepositoryResponseDto`: 외부 API 응답용 DTO (기존 RepoDetailDto에서 이름 변경)



## ❓ 기타 의견
**DB 스키마가 변경되었으므로 기존 테스트 DB의 데이터를 모두 삭제한 후 애플리케이션을 재실행해 주세요.**
