### PR TITLE
reafactor: repo 수집기 수정

### DIFF
--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/github/GithubRepositoryUpsertDto.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/dto/github/GithubRepositoryUpsertDto.java
@@ -29,31 +29,27 @@ public record GithubRepositoryUpsertDto(
     /** GithubRepositoryResponseDto → UpsertDto 변환 */
     public static GithubRepositoryUpsertDto from(GithubRepositoryResponseDto dto) {
         return new GithubRepositoryUpsertDto(
-                dto.id(),
-                dto.ownerNameOnly(),
-                dto.repoNameOnly(),
-                nvl(dto.defaultBranch(), "main"),
-                dto.watchers(),
-                dto.stargazersCount(),
-                dto.forks(),
-                null, // dependency → hydrate 단계에서
+                dto.githubRepoId(),
+                dto.ownerName(),
+                dto.repoName(),
+                dto.defaultBranch(),
+                dto.watcher(),
+                dto.star(),
+                dto.fork(),
+                dto.dependency(),
                 dto.description(),
-                null, // readme → hydrate 단계에서
-                dto.license() != null ? dto.license().name() : null,
-                toUtcLocal(dto.createdAt()),
-                toUtcLocal(dto.updatedAt()),
-                toUtcLocal(dto.pushedAt()),
-                null, // additionalData → hydrate 단계에서
-                null, // contributor → hydrate 단계에서
+                dto.readme(),
+                dto.license(),
+                toUtcLocal(dto.githubRepositoryCreatedAt()),
+                toUtcLocal(dto.githubRepositoryUpdatedAt()),
+                toUtcLocal(dto.githubPushedAt()),
+                dto.additionalData(),
+                dto.contributor(),
                 dto.isPrivate()
         );
     }
 
     // ---- private helpers ----
-    private static String nvl(String v, String def) {
-        return (v == null || v.isBlank()) ? def : v;
-    }
-
     private static LocalDateTime toUtcLocal(OffsetDateTime odt) {
         return odt != null ? odt.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
     }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/response/GithubRepositoryResponseDto.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/response/GithubRepositoryResponseDto.java
@@ -1,45 +1,111 @@
 package com.sosd.sosd_backend.github_collector.dto.response;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sosd.sosd_backend.github_collector.dto.response.graphql.GithubRepositoryGraphQLResult;
+
+/** RepoOverview → 평탄화 DTO (lastStarredAt/lastCollectedAt 제외) */
 public record GithubRepositoryResponseDto(
-        long id,
-        @JsonProperty("full_name") String fullName,
-        @JsonProperty("private") boolean isPrivate, //
-        OwnerDto owner,
+        Long githubRepoId,
+        String ownerName,
+        String repoName,
+        String fullName,
+        String defaultBranch,
+        Integer watcher,
+        Integer star,
+        Integer fork,
+        Integer dependency,
         String description,
-        @JsonProperty("created_at") OffsetDateTime createdAt,
-        @JsonProperty("updated_at") OffsetDateTime updatedAt,
-        @JsonProperty("pushed_at") OffsetDateTime pushedAt,
-        String language,
-        @JsonProperty("stargazers_count") int stargazersCount,
-        int forks,
-        LicenseDto license,
-        @JsonProperty("default_branch") String defaultBranch,
-        int watchers
+        String readme,
+        String license,
+        OffsetDateTime githubRepositoryCreatedAt,
+        OffsetDateTime githubRepositoryUpdatedAt,
+        OffsetDateTime githubPushedAt,
+        String additionalData,
+        Integer contributor,
+        Boolean isPrivate
 ) {
-    public record OwnerDto(
-            String login,
-            long id
-    ) {}
+    /** GraphQL 응답 → 평탄화 DTO */
+    public static GithubRepositoryResponseDto from(GithubRepositoryGraphQLResult gql) {
+        var repo = Objects.requireNonNull(gql.repository(), "repository is null");
 
-    public record LicenseDto(
-            String name
-    ) {}
+        Long repoId = repo.databaseId() != null ? repo.databaseId().longValue() : null;
+        String nameWithOwner = repo.nameWithOwner();
+        String owner = splitOwner(nameWithOwner);
+        String name  = splitRepo(nameWithOwner);
 
-    /** fullName에서 repoName 부분만 추출 */
-    public String repoNameOnly() {
-        if (fullName == null) return null;
-        int idx = fullName.indexOf('/');
-        return (idx >= 0 && idx + 1 < fullName.length()) ? fullName.substring(idx + 1) : fullName;
+        String defaultBranch = repo.defaultBranchRef() != null
+                ? repo.defaultBranchRef().name() : "main";
+
+        Integer watchers   = repo.watchers() != null ? repo.watchers().totalCount() : null;
+        Integer dependency = repo.dependencyGraphManifests() != null ? repo.dependencyGraphManifests().totalCount() : null;
+        String readme      = repo.object() != null ? repo.object().text() : null;
+        String license     = repo.licenseInfo() != null ? repo.licenseInfo().name() : null;
+
+        String additionalJson = buildLanguagesJson(repo.languages());
+        Integer contributor = repo.mentionableUsers() != null ? repo.mentionableUsers().totalCount() : null;
+
+        return new GithubRepositoryResponseDto(
+                repoId,
+                owner,
+                name,
+                nameWithOwner,
+                defaultBranch,
+                watchers,
+                repo.stargazerCount(),
+                repo.forkCount(),
+                dependency,
+                repo.description(),
+                readme,
+                license,
+                repo.createdAt(),
+                repo.updatedAt(),
+                repo.pushedAt(),
+                additionalJson,
+                contributor,
+                repo.isPrivate()
+        );
     }
 
-    /** fullName에서 ownerName 부분만 추출 */
-    public String ownerNameOnly() {
-        if (fullName == null) return null;
-        int idx = fullName.indexOf('/');
-        return (idx > 0) ? fullName.substring(0, idx) : null;
+    // ===== helpers =====
+    private static String splitOwner(String nameWithOwner) {
+        if (nameWithOwner == null) return null;
+        int idx = nameWithOwner.indexOf('/');
+        return idx > 0 ? nameWithOwner.substring(0, idx) : null;
+    }
+    private static String splitRepo(String nameWithOwner) {
+        if (nameWithOwner == null) return null;
+        int idx = nameWithOwner.indexOf('/');
+        return (idx >= 0 && idx < nameWithOwner.length() - 1) ? nameWithOwner.substring(idx + 1) : null;
+    }
+
+    /** languages → JSON: { "totalSize":..., "languages":[{"name":"Java","size":123}, ...] } */
+    private static String buildLanguagesJson(GithubRepositoryGraphQLResult.Languages languages) {
+        if (languages == null) return null;
+
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("totalSize", languages.totalSize());
+
+        List<Map<String, Object>> list = Optional.ofNullable(languages.edges())
+                .orElseGet(List::of)
+                .stream()
+                .map(edge -> {
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    m.put("name", edge != null && edge.node() != null ? edge.node().name() : null);
+                    m.put("size", edge != null ? edge.size() : null);
+                    return m;
+                })
+                .collect(Collectors.toList());
+
+        root.put("languages", list);
+
+        try {
+            return new ObjectMapper().writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            return "{\"error\":\"failed to serialize languages\"}";
+        }
     }
 }

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/response/graphql/GithubRepositoryGraphQLResult.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/dto/response/graphql/GithubRepositoryGraphQLResult.java
@@ -1,0 +1,70 @@
+package com.sosd.sosd_backend.github_collector.dto.response.graphql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * GraphQL RepoOverview 쿼리 응답 매핑용 DTO
+ */
+public record GithubRepositoryGraphQLResult(
+        Repository repository,
+        GithubRateLimit rateLimit
+) {
+    public record Repository(
+            Integer databaseId,
+            String nameWithOwner,
+            Boolean isPrivate,
+            DefaultBranchRef defaultBranchRef,
+            String description,
+            Integer stargazerCount,
+            Watchers watchers,
+            Integer forkCount,
+            LicenseInfo licenseInfo,
+            OffsetDateTime createdAt,
+            OffsetDateTime updatedAt,
+            OffsetDateTime pushedAt,
+            ReadmeObject object,
+            Languages languages,
+            DependencyGraphManifests dependencyGraphManifests,
+            MentionableUsers mentionableUsers
+    ) {}
+
+    public record DefaultBranchRef(
+            String name
+    ) {}
+
+    public record Watchers(
+            Integer totalCount
+    ) {}
+
+    public record LicenseInfo(
+            String name
+    ) {}
+
+    public record ReadmeObject(
+            String text
+    ) {}
+
+    public record Languages(
+            Integer totalSize,
+            List<LanguageEdge> edges
+    ) {}
+
+    public record LanguageEdge(
+            Integer size,
+            LanguageNode node
+    ) {}
+
+    public record LanguageNode(
+            String name
+    ) {}
+
+    public record DependencyGraphManifests(
+            Integer totalCount
+    ) {}
+    public record MentionableUsers(
+            Integer totalCount
+    ) {}
+}

--- a/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/orchestrator/GithubAccountCollectionOrchestrator.java
+++ b/sosd-backend/src/main/java/com/sosd/sosd_backend/github_collector/orchestrator/GithubAccountCollectionOrchestrator.java
@@ -2,12 +2,16 @@ package com.sosd.sosd_backend.github_collector.orchestrator;
 
 import com.sosd.sosd_backend.dto.github.GithubRepositoryUpsertDto;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
+import com.sosd.sosd_backend.github_collector.dto.collect.context.RepoListCollectContext;
+import com.sosd.sosd_backend.github_collector.dto.collect.result.CollectResult;
+import com.sosd.sosd_backend.github_collector.dto.collect.result.TimeCursor;
 import com.sosd.sosd_backend.github_collector.dto.ref.GithubAccountRef;
 import com.sosd.sosd_backend.github_collector.dto.ref.RepoRef;
 import com.sosd.sosd_backend.github_collector.dto.response.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.service.github.RepoUpsertService;
 import org.springframework.stereotype.Component;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Component
@@ -24,7 +28,15 @@ public class GithubAccountCollectionOrchestrator {
      */
     public void collectByGithubAccount(GithubAccountRef githubAccountRef){
         // 1) 해당 유저가 기여한 모든 레포 수집
-        List<GithubRepositoryResponseDto> repoResponseDtos = repoCollector.getAllContributedRepos(githubAccountRef.githubLoginUsername());
+
+        RepoListCollectContext ctx = new RepoListCollectContext(
+                githubAccountRef,
+                OffsetDateTime.parse("2010-01-01T00:00:00Z") // TODO: DB의 마지막 수집 시점으로 변경
+        );
+        CollectResult<GithubRepositoryResponseDto, TimeCursor> collectedRepos =
+                repoCollector.collect(ctx);
+
+        List<GithubRepositoryResponseDto> repoResponseDtos = collectedRepos.results();
 
         // 2) 도메인 모델 뱐환
         List<GithubRepositoryUpsertDto> repoUpsertDtos = repoResponseDtos.stream()

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
@@ -2,6 +2,7 @@ package com.sosd.sosd_backend.github_collector;
 
 import com.sosd.sosd_backend.github_collector.dto.response.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
+import com.sosd.sosd_backend.github_collector.dto.response.graphql.GithubRepositoryGraphQLResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,11 +18,9 @@ public class RepoCollectTest {
     private RepoCollector repoCollector;
 
     @Test
-    void testGetRepoInfo(){
-        GithubRepositoryResponseDto testRepoDto = repoCollector.getRepoInfo("SKKU-OSP", "SKKU-OSP");
-
-        assertEquals(503242724L, testRepoDto.id(), "Repo ID가 일치하지 않습니다");
-        assertEquals(107451259L, testRepoDto.owner().id(), "Owner ID가 일치하지 않습니다");
+    void testGetRepoInfoByGraphQL(){
+        GithubRepositoryGraphQLResult testRepoDto = repoCollector.getRepoInfoGraphQL("SKKU-OSP", "SKKU-OSP");
+        assertEquals(503242724, testRepoDto.repository().databaseId(), "Repo ID가 일치하지 않습니다");
 
         // 디버깅용 출력
         System.out.println(testRepoDto);

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
@@ -1,5 +1,9 @@
 package com.sosd.sosd_backend.github_collector;
 
+import com.sosd.sosd_backend.github_collector.dto.collect.context.RepoListCollectContext;
+import com.sosd.sosd_backend.github_collector.dto.collect.result.CollectResult;
+import com.sosd.sosd_backend.github_collector.dto.collect.result.TimeCursor;
+import com.sosd.sosd_backend.github_collector.dto.ref.GithubAccountRef;
 import com.sosd.sosd_backend.github_collector.dto.response.GithubRepositoryResponseDto;
 import com.sosd.sosd_backend.github_collector.collector.RepoCollector;
 import com.sosd.sosd_backend.github_collector.dto.response.graphql.GithubRepositoryGraphQLResult;
@@ -7,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,21 +21,38 @@ public class RepoCollectTest {
 
     @Autowired
     private RepoCollector repoCollector;
-
-    @Test
-    void testGetRepoInfoByGraphQL(){
-        GithubRepositoryGraphQLResult testRepoDto = repoCollector.getRepoInfoGraphQL("SKKU-OSP", "SKKU-OSP");
-        assertEquals(503242724, testRepoDto.repository().databaseId(), "Repo ID가 일치하지 않습니다");
-
-        // 디버깅용 출력
-        System.out.println(testRepoDto);
-    }
-
     @Test
     void testGetAllReposFromUser(){
-        List<GithubRepositoryResponseDto> repoLists = repoCollector.getAllContributedRepos("ki011127");
-        for(GithubRepositoryResponseDto repo : repoLists){
-            System.out.println(repo.fullName());
+        GithubAccountRef testAccountRef = new GithubAccountRef(
+                80045655L,
+                "MDQ6VXNlcjgwMDQ1NjU1",
+                "byungKHee",
+                null,
+                null,
+                null
+        );
+
+        RepoListCollectContext ctx = new RepoListCollectContext(
+                testAccountRef,
+                OffsetDateTime.parse("2021-01-01T00:00:00Z")
+        );
+
+        CollectResult<GithubRepositoryResponseDto, TimeCursor> result =
+                repoCollector.collect(ctx);
+
+        System.out.println("=== Collect Result ===");
+        System.out.println("Fetched count: " + result.fetchedCount());
+        System.out.println("Total count: " + result.totalCount());
+        System.out.println("Elapsed time (ms): " + result.elapsedTimeMs());
+        System.out.println("Next cursor: " + result.cursor().lastCollectedTime());
+        List<GithubRepositoryResponseDto> repos = result.results();
+        for (GithubRepositoryResponseDto repo : repos) {
+            System.out.printf("Repo #%d [%s] (createdAt=%s)%n",
+                    repo.githubRepoId(),
+                    repo.fullName(),
+                    repo.githubRepositoryCreatedAt()
+            );
         }
+
     }
 }

--- a/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
+++ b/sosd-backend/src/test/java/com/sosd/sosd_backend/github_collector/RepoCollectTest.java
@@ -34,7 +34,7 @@ public class RepoCollectTest {
 
         RepoListCollectContext ctx = new RepoListCollectContext(
                 testAccountRef,
-                OffsetDateTime.parse("2021-01-01T00:00:00Z")
+                OffsetDateTime.parse("2025-08-26T00:00:00Z")
         );
 
         CollectResult<GithubRepositoryResponseDto, TimeCursor> result =


### PR DESCRIPTION
## 📌 PR 개요

`RepoCollector` 리팩토링 작업 진행

## 🛠 작업 내용

- Repo 상세 정보를 가져오는 api를 rest에서 GraphQL로 변경
    - rest api의 경우 languages, dependency 등의 필드를 가져올 때 한 번의 요청을 더 해야했지만, graphql로는 한 번에 가져오기 가능
- 기여 레포 추적 로직 변경
    - PR/Issue에서 추출할 때 created 쿼리를 넣어서 증분형 수집
    - `fetchReposFromUserRepos`, `fetchReposFromSearchIssues`, `fetchReposFromEvents` 총 3가지를 통해서 기여한 레포를 추적하는데, 최근에 수집이 된 유저에 대해서는 일부만 실행하여 성능 향상
    - `fetchReposFromUserRepos`: 한 번도 수집된 적 없는 신규 유저의 경우만 호출
    - `fetchReposFromSearchIssues`: 한 번도 수집된 적 없거나, 마지막 수집 기간이 2일이 넘은 유저(2일 동안 events 300개가 넘어갈 수도 있기 때문에 최대한 보수적으로 잡음)
    -  `fetchReposFromEvents`: 모든 유저에 대해 수집

## ❓ 기타 의견

- 위와 같이 처리했음에도 활동이 매우 많은 유저의 경우에는 events의 300개 만으로도 총 처리 시간이 10초가 넘어감. 병목구간은 full_name을 가져온 후 각각 상세 정보를 요청하는 과정에서 생기기 때문에 DB에 있는 레포는 요청을 보내지 않는 식으로 수정할 계획 
